### PR TITLE
Validate your input

### DIFF
--- a/bin/netjsonconfig
+++ b/bin/netjsonconfig
@@ -57,12 +57,13 @@ output.add_argument('--backend', '-b',
 
 output.add_argument('--method', '-m',
                     required=True,
-                    choices=['render', 'generate', 'write'],
+                    choices=['render', 'generate', 'write', 'validate'],
                     action='store',
                     help='Backend method to use. '
                          '"render" returns the configuration in text format'
                          '"generate" returns a tar.gz archive as output; '
-                         '"write" is like generate but writes to disk; ')
+                         '"write" is like generate but writes to disk; '
+                         '"validate" only validate the resulting NetJSON;')
 
 output.add_argument('--args', '-a',
                     nargs='*',  # zero or more

--- a/docs/source/general/commandline_utility.rst
+++ b/docs/source/general/commandline_utility.rst
@@ -18,7 +18,7 @@ Check out the available options yourself with::
     $ netjsonconfig --help
     usage: netjsonconfig [-h] --config CONFIG
                          [--templates [TEMPLATES [TEMPLATES ...]]] --backend
-                         {openwrt,openwisp} --method {render,generate,write}
+                         {openwrt,openwisp} --method {render,generate,write,validate}
                          [--args [ARGS [ARGS ...]]] [--verbose] [--version]
 
     Converts a NetJSON DeviceConfiguration object to native router configurations.
@@ -38,11 +38,12 @@ Check out the available options yourself with::
     output:
       --backend {openwrt,openwisp}, -b {openwrt,openwisp}
                             Configuration backend: openwrt or openwisp
-      --method {render,generate,write}, -m {render,generate,write}
+      --method {render,generate,write}, -m {render,generate,write, validate}
                             Backend method to use. "render" returns the
                             configuration in text format"generate" returns a
                             tar.gz archive as output; "write" is like generate but
-                            writes to disk;
+                            writes to disk, "validate" validates the resulting NetJSON
+                            against the backend schema;
       --args [ARGS [ARGS ...]], -a [ARGS [ARGS ...]]
                             Optional arguments that can be passed to methods
 
@@ -65,6 +66,9 @@ Here's the common use cases explained::
    # same as previous but exclude additional files
    netjsonconfig --config config.json --backend openwrt --method render --args files=0
 
+   # validate the config.json file against the openwrt backend
+   netjsonconfig --config config.json --backend openwrt --method validate
+
    # abbreviated options
    netjsonconfig -c config.json -b openwrt -m render -a files=0
 
@@ -74,6 +78,10 @@ Here's the common use cases explained::
 Using templates::
 
     netjsonconfig -c config.json -t template1.json template2.json -b openwrt -m render
+
+    # validate the result of merging config.json, template1.json and template2.json 
+    # against the openwrt backend
+    netjsonconfig -c config.json -t template1.json template2.json -b openwrt -m validate
 
 Environment variables
 ---------------------

--- a/netjsonconfig/exceptions.py
+++ b/netjsonconfig/exceptions.py
@@ -1,6 +1,8 @@
 class NetJsonConfigException(Exception):
     """ root netjsonconfig exception """
-    pass
+
+    def __str__(self):
+        return "%s %s %s" % (self.__class__.__name__, self.message, self.details)
 
 
 class ValidationError(NetJsonConfigException):

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -29,6 +29,16 @@ class TestBin(unittest.TestCase, _TabsMixin):
         with self.assertRaises(subprocess.CalledProcessError):
             subprocess.check_output(command, shell=True)
 
+    def test_check_invalid_netjson(self):
+        command = '''netjsonconfig -c '{ "interfaces":["w"] }' -b openwrt -m validate'''
+        with self.assertRaises(subprocess.CalledProcessError):
+            subprocess.check_output(command, shell=True)
+
+    def test_check_invalid_netjson_verbose(self):
+        command = '''netjsonconfig -c '{ "interfaces":["w"] }' -b openwrt -m validate --verbose'''
+        with self.assertRaises(subprocess.CalledProcessError):
+            subprocess.check_output(command, shell=True)
+
     def test_empty_netjson(self):
         output = subprocess.check_output("netjsonconfig -c '{}' -b openwrt -m render", shell=True)
         self.assertEqual(output.decode(), '')


### PR DESCRIPTION
This pr adds a command to validate the netjson input after it has been merged with templates and such.

As an example, using the NetJSON found [here](http://netjson.org/rfc.html#DeviceConfiguration-example)

```
netjsonconfig -c example.json -b openwrt -m validate --verbose
netjsonconfig: JSON Schema violation
ValidationError {u'name': u'radio0', u'country': u'en', u'disabled': False, u'phy': u'phy0', u'tx_power': 18, u'channel': 149, u'channel_width': 20} is not valid under any of the given schemas {u'name': u'radio0', u'country': u'en', u'disabled': False, u'phy': u'phy0', u'tx_power': 18, u'channel': 149, u'channel_width': 20} is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['radios']['items']:
    {'oneOf': [{'$ref': '#/definitions/radio_80211gn_settings'},
               {'$ref': '#/definitions/radio_80211an_settings'},
               {'$ref': '#/definitions/radio_80211ac_2ghz_settings'},
               {'$ref': '#/definitions/radio_80211ac_5ghz_settings'},
               {'$ref': '#/definitions/radio_80211bg_settings'},
               {'$ref': '#/definitions/radio_80211a_settings'}],
     'title': 'Radio'}

On instance['radios'][0]:
    {u'channel': 149,
     u'channel_width': 20,
     u'country': u'en',
     u'disabled': False,
     u'name': u'radio0',
     u'phy': u'phy0',
     u'tx_power': 18}
```