### PR TITLE
Travel all the errors in report

### DIFF
--- a/netjsonconfig/exceptions.py
+++ b/netjsonconfig/exceptions.py
@@ -1,9 +1,27 @@
+from functools import reduce
+
+
+def list_error_in_subschema(jsonschema_error):
+    sub_errors = []
+    for validator_value, error in zip(jsonschema_error.validator_value, jsonschema_error.context):
+        sub_errors.append((validator_value, error.message))
+        if error.context:
+            sub_errors += list_error_in_subschema(error)
+    return sub_errors
+
+
 class NetJsonConfigException(Exception):
     """
     Root netjsonconfig exception
     """
     def __str__(self):
-        return "%s %s %s" % (self.__class__.__name__, self.message, self.details)
+        suberrors = list_error_in_subschema(self.details)
+
+        default_message = "%s %s\n" % (self.__class__.__name__, self.details,)
+        suberror_fmt = '\nAgainst schema %s\n%s\n'
+        suberror_message = reduce(lambda x, y: x + suberror_fmt % y, suberrors, '')
+
+        return default_message + suberror_message
 
 
 class ValidationError(NetJsonConfigException):

--- a/tests/test_jsonschema_error.py
+++ b/tests/test_jsonschema_error.py
@@ -1,0 +1,112 @@
+import unittest
+
+from jsonschema import ValidationError, validate
+
+from netjsonconfig.exceptions import list_error_in_subschema
+
+schema = {
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'type': 'object',
+        'additionalProperties': True,
+        'definitions': {
+            'spam_object': {
+                'additionalProperties': True,
+                'required': [
+                    'spam',
+                ],
+                'properties': {
+                    'spam': {
+                        'type': 'string',
+                    },
+                },
+            },
+            'eggs_object': {
+                'additionalProperties': True,
+                'required': [
+                    'eggs',
+                ],
+                'properties': {
+                    'eggs': {
+                        'type': 'boolean',
+                    },
+                },
+            },
+        },
+        'properties': {
+            'test_object': {
+                'type': 'object',
+                'oneOf': [
+                    {'$ref': '#/definitions/spam_object'},
+                    {'$ref': '#/definitions/eggs_object'},
+                ],
+            }
+        },
+}
+
+
+class TestJsonSchema(unittest.TestCase):
+    """
+    tests ValidationError helpers
+    """
+
+    def test_spam_object(self):
+        test_i = {
+                'test_object': {
+                    'spam': 'lots of',
+                },
+        }
+
+        validate(test_i, schema)
+
+    def test_eggs_object(self):
+        test_i = {
+                'test_object': {
+                    'eggs': True,
+                },
+        }
+
+        validate(test_i, schema)
+
+    def test_burrito_object(self):
+        test_i = {
+                'test_object': {
+                    'burrito': 'yes',
+                },
+        }
+
+        self.assertRaises(ValidationError, validate, test_i, schema)
+
+    def test_burrito_error_message(self):
+        test_i = {
+                'test_object': {
+                    'burrito': 'yes',
+                },
+        }
+
+        with self.assertRaises(ValidationError) as error_container:
+            validate(test_i, schema)
+
+        message_list = [
+                "'spam' is a required property",
+                "'eggs' is a required property",
+        ]
+
+        self.assertEqual([e.message for e in error_container.exception.context], message_list)
+
+    def test_list_error_in_subschema(self):
+        test_i = {
+                'test_object': {
+                    'burrito': 'yes',
+                },
+        }
+
+        with self.assertRaises(ValidationError) as error_container:
+            validate(test_i, schema)
+
+        suberror_list = [
+                ({'$ref': '#/definitions/spam_object'}, "'spam' is a required property"),
+
+                ({'$ref': '#/definitions/eggs_object'}, "'eggs' is a required property"),
+        ]
+
+        self.assertEqual(list_error_in_subschema(error_container.exception), suberror_list)


### PR DESCRIPTION
An example is wort thousands words

```json

{
	"type": "DeviceConfiguration",
	"general": {},
	"interfaces": [
		{
			"type": "wireless",
			"wireless": {
				"radio": "ath0",
				"mode": "access_point",
				"ssid": "test"
			},
			"addresses": [
				{
					"address": "192.168.1.20",
					"mask": 24,
					"family": "ipv4",
					"proto": "static"
				}
			]
		}
	]
}
```

Raise validation errors

```
netjsonconfig: JSON Schema violation
ValidationError {u'wireless': {u'radio': u'ath0', u'mode': u'access_point', u'ssid': u'test'}, u'type': u'wireless', u'addresses': [{u'address': u'192.168.1.20', u'mask': 24, u'family': u'ipv4', u'proto': u'static'}]} is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['interfaces']['items']:
    {'oneOf': [{'$ref': '#/definitions/network_interface'},
               {'$ref': '#/definitions/wireless_interface'},
               {'$ref': '#/definitions/bridge_interface'}],
     'title': 'Interface'}

On instance['interfaces'][0]:
    {u'addresses': [{u'address': u'192.168.1.20',
                     u'family': u'ipv4',
                     u'mask': 24,
                     u'proto': u'static'}],
     u'type': u'wireless',
     u'wireless': {u'mode': u'access_point',
                   u'radio': u'ath0',
                   u'ssid': u'test'}}

Against schema {'$ref': '#/definitions/network_interface'}
u'wireless' is not one of ['ethernet', 'virtual', 'loopback', 'other']

Against schema {'$ref': '#/definitions/wireless_interface'}
'name' is a required property

Against schema {'$ref': '#/definitions/bridge_interface'}
'name' is a required property

```