### PR TITLE
[python2] Fixed py2-ipaddress related unicode bug

### DIFF
--- a/netjsonconfig/backends/openwrt/converters/interfaces.py
+++ b/netjsonconfig/backends/openwrt/converters/interfaces.py
@@ -68,7 +68,7 @@ class Interfaces(OpenWrtConverter):
             # do not use CIDR notation when using a single ipv4
             # see https://github.com/openwisp/netjsonconfig/issues/54
             if len(static.get('ipaddr', [])) == 1:
-                network = ip_interface(static['ipaddr'][0])
+                network = ip_interface(six.text_type(static['ipaddr'][0]))
                 static['ipaddr'] = str(network.ip)
                 static['netmask'] = str(network.netmask)
             # do not use lists when using a single ipv6 address
@@ -269,7 +269,7 @@ class Interfaces(OpenWrtConverter):
         return interface
 
     def __netjson_address(self, address, interface):
-        ip = ip_interface(address)
+        ip = ip_interface(six.text_type(address))
         family = 'ipv{0}'.format(ip.version)
         netjson = OrderedDict((
             ('address', str(ip.ip)),
@@ -279,7 +279,7 @@ class Interfaces(OpenWrtConverter):
         ))
         uci_gateway_key = 'gateway' if family == 'ipv4' else 'ip6gw'
         gateway = interface.get(uci_gateway_key, None)
-        if gateway and ip_address(gateway) in ip.network:
+        if gateway and ip_address(six.text_type(gateway)) in ip.network:
             netjson['gateway'] = gateway
             del interface[uci_gateway_key]
         return netjson

--- a/netjsonconfig/backends/openwrt/converters/routes.py
+++ b/netjsonconfig/backends/openwrt/converters/routes.py
@@ -1,5 +1,7 @@
 from ipaddress import ip_interface
 
+import six
+
 from ..schema import schema
 from .base import OpenWrtConverter
 
@@ -16,7 +18,7 @@ class Routes(OpenWrtConverter):
         return result
 
     def __intermediate_route(self, route, index):
-        network = ip_interface(route.pop('destination'))
+        network = ip_interface(six.text_type(route.pop('destination')))
         target = network.ip if network.version == 4 else network.network
         route.update({
             '.type': 'route{0}'.format('6' if network.version == 6 else ''),
@@ -50,7 +52,7 @@ class Routes(OpenWrtConverter):
             network = '{0}/{1}'.format(network, route.pop('netmask'))
         route.update({
             "device": route.pop('interface'),
-            "destination": str(ip_interface(network)),
+            "destination": str(ip_interface(six.text_type(network))),
             "next": route.pop('gateway'),
             "cost": route.pop('metric', self._schema['properties']['cost']['default'])
         })

--- a/netjsonconfig/backends/openwrt/converters/rules.py
+++ b/netjsonconfig/backends/openwrt/converters/rules.py
@@ -1,5 +1,7 @@
 from ipaddress import ip_network
 
+import six
+
 from ..schema import schema
 from .base import OpenWrtConverter
 
@@ -21,9 +23,9 @@ class Rules(OpenWrtConverter):
         dest_net = None
         family = 4
         if 'src' in rule:
-            src_net = ip_network(rule['src'])
+            src_net = ip_network(six.text_type(rule['src']))
         if 'dest' in rule:
-            dest_net = ip_network(rule['dest'])
+            dest_net = ip_network(six.text_type(rule['dest']))
         if dest_net or src_net:
             family = dest_net.version if dest_net else src_net.version
         rule.update({


### PR DESCRIPTION
For some strange reason this bug popped out of the blue.
Apparently arguments passed to the ipaddress library must be unicode strings.

No idea why this didn't come up earlier.

Closes #97