### PR TITLE
wip: print full traceback when verbose

### DIFF
--- a/bin/netjsonconfig
+++ b/bin/netjsonconfig
@@ -5,6 +5,7 @@ import sys
 import six
 import argparse
 import netjsonconfig
+import traceback
 
 description = """
 Converts a NetJSON DeviceConfiguration object to native router configurations.
@@ -197,5 +198,8 @@ except netjsonconfig.exceptions.ValidationError as e:
     print(message + info)
     sys.exit(4)
 except TypeError as e:
+    if args.verbose:
+        traceback.print_exc()
+
     print('netjsonconfig: {0}'.format(e))
     sys.exit(5)


### PR DESCRIPTION
Every other error from the netjson library has a custom error reporting but when I am working on a new feature it's easy to mess things up and I wuold like to know what and why.

This PR should print the full traceback for error others than ValidationError when I use the verbose flag.

This should get rid of the "remove the last exception handling lines" during development 