### PR TITLE
[feature] Add options username and password to interface settings in the OpenWRT backend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Change log
 ==========
 
+- Added dialup interface handling for openwrt backend.
+  This change is backward incompatible for custom defined interfaces of the
+  proto type ``other``.
+
 Version 0.8.1 [2020-05-28]
 --------------------------
 

--- a/docs/source/backends/openwrt.rst
+++ b/docs/source/backends/openwrt.rst
@@ -288,11 +288,12 @@ The network interface settings reside in the ``interfaces`` key of the
 `NetJSON interface objects <http://netjson.org/rfc.html#interfaces1>`_
 (see the link for the detailed specification).
 
-There are 3 main type of interfaces:
+There are 4 main types of interfaces:
 
 * **network interfaces**: may be of type ``ethernet``, ``virtual``, ``loopback`` or ``other``
 * **wireless interfaces**: must be of type ``wireless``
 * **bridge interfaces**: must be of type ``bridge``
+* **dialup interfaces**: must be of type ``dialup``
 
 Interface object extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -376,7 +377,12 @@ Will be rendered as follows::
 
     package network
 
-    config interface 'eth0'        option ifname 'eth0'        option ip6addr 'fdb4:5f35:e8fd::1/48'        option ipaddr '10.27.251.1'        option netmask '255.255.255.0'        option proto 'static'
+    config interface 'eth0'
+        option ifname 'eth0'
+        option ip6addr 'fdb4:5f35:e8fd::1/48'
+        option ipaddr '10.27.251.1'
+        option netmask '255.255.255.0'
+        option proto 'static'
 
 DNS servers and search domains
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -431,7 +437,22 @@ Will return the following UCI output::
 
     package network
 
-    config interface 'eth0'            option dns '10.11.12.13 8.8.8.8'            option dns_search 'openwisp.org netjson.org'            option ifname 'eth0'            option ipaddr '192.168.1.1'            option netmask '255.255.255.0'            option proto 'static'    config interface 'eth1'            option dns_search 'openwisp.org netjson.org'            option ifname 'eth1'            option proto 'dhcp'    config interface 'eth1_31'            option ifname 'eth1.31'            option proto 'none'
+    config interface 'eth0'
+            option dns '10.11.12.13 8.8.8.8'
+            option dns_search 'openwisp.org netjson.org'
+            option ifname 'eth0'
+            option ipaddr '192.168.1.1'
+            option netmask '255.255.255.0'
+            option proto 'static'
+
+    config interface 'eth1'
+            option dns_search 'openwisp.org netjson.org'
+            option ifname 'eth1'
+            option proto 'dhcp'
+
+    config interface 'eth1_31'
+            option ifname 'eth1.31'
+            option proto 'none'
 
 DHCP ipv6 ethernet interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1189,6 +1210,54 @@ UCI Output::
             option network 'wlan0'
             option password 'test-password'
             option ssid 'enterprise-client'
+
+Dialup settings
+---------------
+
+Interfaces of type ``dialup`` contain a few options that are specific to dialup connections.
+
+The ``OpenWrt`` backend NetJSON extensions for dialup interfaces:
+
++--------------+---------+-----------+------------------------------------------------------------------------------------------------------------+
+| key name     | type    | default   | allowed values                                                                                             |
++==============+=========+===========+============================================================================================================+
+| ``proto``    | string  | ``pppoe`` | ``3g``, ``6in4``, ``aiccu``, ``l2tp``, ``ncm``, ``ppp``, ``pppoa``, ``pppoe``, ``pptp``, ``qmi``, ``wwan`` |
++--------------+---------+-----------+------------------------------------------------------------------------------------------------------------+
+| ``password`` | string  | ``""``    |                                                                                                            |
++--------------+---------+-----------+------------------------------------------------------------------------------------------------------------+
+| ``username`` | string  | ``""``    |                                                                                                            |
++--------------+---------+-----------+------------------------------------------------------------------------------------------------------------+
+
+Dialup interface example
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following *configuration dictionary*:
+
+.. code-block:: python
+
+    {
+        "interfaces": [
+            {
+                "name": "dsl0",
+                "network": "xdsl",
+                "proto": "pppoe",
+                "password": "jf93nf82o023$",
+                "username": "dsluser",
+                "mtu": 1448
+            }
+        ]
+    }
+
+Will be rendered as follows::
+
+    package network
+
+    config interface 'xdsl'               
+            option ifname 'dsl0'
+            option proto 'pppoe'     
+            option username 'dsluser' 
+            option password 'jf93nf82o023$'
+            option mtu '1448'          
 
 Radio settings
 --------------

--- a/netjsonconfig/backends/openwrt/converters/interfaces.py
+++ b/netjsonconfig/backends/openwrt/converters/interfaces.py
@@ -248,7 +248,8 @@ class Interfaces(OpenWrtConverter):
             return interface
         if proto not in ['static', 'dhcp', 'dhcpv6', 'none']:
             interface['proto'] = proto
-            interface['type'] = 'other'
+            interface['type'] = self.__get_special_interface_type(interface)
+
         addresses = []
         ipv4 = interface.pop('ipaddr', [])
         ipv6 = interface.pop('ip6addr', [])
@@ -271,6 +272,15 @@ class Interfaces(OpenWrtConverter):
         if addresses:
             interface['addresses'] = addresses
         return interface
+
+    def __get_special_interface_type(self, interface):
+        username = interface.get('username', False)
+        password = interface.get('password', False)
+
+        if username and password:
+            return 'dialup'
+
+        return 'other'
 
     def __netjson_address(self, address, interface):
         ip = ip_interface(address)

--- a/netjsonconfig/backends/openwrt/schema.py
+++ b/netjsonconfig/backends/openwrt/schema.py
@@ -114,14 +114,16 @@ schema = merge_config(
             },
             "dialup_interface": {
                 "title": "Dialup interface",
-                "required": [
-                    "proto",
-                    "username",
-                    "password"
-                ],
+                "required": ["proto", "username", "password"],
                 "allOf": [
                     {
                         "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["dialup"],
+                                "default": "dialup",
+                                "propertyOrder": 1,
+                            },
                             "proto": {
                                 "type": "string",
                                 "enum": [
@@ -135,7 +137,7 @@ schema = merge_config(
                                     "pppoe",
                                     "pptp",
                                     "qmi",
-                                    "wwan"
+                                    "wwan",
                                 ],
                                 "default": "pppoe",
                                 "propertyOrder": 8,
@@ -149,11 +151,11 @@ schema = merge_config(
                                 "type": "string",
                                 "description": "password for authentication in protocols like PPPoE",
                                 "propertyOrder": 10,
-                            }
+                            },
                         }
                     },
                     {"$ref": "#/definitions/interface_settings"},
-                ]
+                ],
             },
             "base_radio_settings": {
                 "properties": {
@@ -209,17 +211,7 @@ schema = merge_config(
                 }
             },
             "interfaces": {
-                "type": "array",
-                "title": "Interfaces",
-                "uniqueItems": True,
-                "additionalItems": True,
-                "propertyOrder": 2,
-                "items": {
-                    "title": "Interface",
-                    "oneOf": [
-                        {"$ref": "#/definitions/dialup_interface"}
-                    ]
-                }
+                "items": {"oneOf": [{"$ref": "#/definitions/dialup_interface"}]}
             },
             "routes": {
                 "items": {

--- a/netjsonconfig/backends/openwrt/schema.py
+++ b/netjsonconfig/backends/openwrt/schema.py
@@ -112,6 +112,49 @@ schema = merge_config(
                     }
                 ]
             },
+            "dialup_interface": {
+                "title": "Dialup interface",
+                "required": [
+                    "proto",
+                    "username",
+                    "password"
+                ],
+                "allOf": [
+                    {
+                        "properties": {
+                            "proto": {
+                                "type": "string",
+                                "enum": [
+                                    "3g",
+                                    "6in4",
+                                    "aiccu",
+                                    "l2tp",
+                                    "ncm",
+                                    "ppp",
+                                    "pppoa",
+                                    "pppoe",
+                                    "pptp",
+                                    "qmi",
+                                    "wwan"
+                                ],
+                                "default": "pppoe",
+                                "propertyOrder": 8,
+                            },
+                            "username": {
+                                "type": "string",
+                                "description": "username for authentication in protocols like PPPoE",
+                                "propertyOrder": 9,
+                            },
+                            "password": {
+                                "type": "string",
+                                "description": "password for authentication in protocols like PPPoE",
+                                "propertyOrder": 10,
+                            }
+                        }
+                    },
+                    {"$ref": "#/definitions/interface_settings"},
+                ]
+            },
             "base_radio_settings": {
                 "properties": {
                     "driver": {
@@ -163,6 +206,19 @@ schema = merge_config(
             "general": {
                 "properties": {
                     "timezone": {"enum": list(timezones.keys()), "default": "UTC"}
+                }
+            },
+            "interfaces": {
+                "type": "array",
+                "title": "Interfaces",
+                "uniqueItems": True,
+                "additionalItems": True,
+                "propertyOrder": 2,
+                "items": {
+                    "title": "Interface",
+                    "oneOf": [
+                        {"$ref": "#/definitions/dialup_interface"}
+                    ]
                 }
             },
             "routes": {

--- a/tests/openwrt/test_dialup.py
+++ b/tests/openwrt/test_dialup.py
@@ -1,0 +1,42 @@
+import unittest
+
+from netjsonconfig import OpenWrt
+from netjsonconfig.utils import _TabsMixin
+
+
+class TestDialup(unittest.TestCase, _TabsMixin):
+    maxDiff = None
+
+    _dialup_interface_netjson = {
+        "interfaces": [
+            {
+                "mtu": 1448,
+                "network": "xdsl",
+                "type": "dialup",
+                "name": "dsl0",
+                "password": "jf93nf82o023$",
+                "username": "dsluser",
+                "proto": "pppoe",
+            },
+        ]
+    }
+
+    _dialup_interface_uci = """package network
+
+config interface 'xdsl'
+    option ifname 'dsl0'
+    option mtu '1448'
+    option password 'jf93nf82o023$'
+    option proto 'pppoe'
+    option username 'dsluser'
+"""
+
+    def test_render_dialup_interface(self):
+        result = OpenWrt(self._dialup_interface_netjson).render()
+        expected = self._tabs(self._dialup_interface_uci)
+        self.assertEqual(result, expected)
+
+    def test_parse_dialup_interface(self):
+        result = OpenWrt(native=self._dialup_interface_uci).config
+        expected = self._dialup_interface_netjson
+        self.assertDictEqual(result, expected)

--- a/tests/openwrt/test_interfaces.py
+++ b/tests/openwrt/test_interfaces.py
@@ -601,25 +601,21 @@ config interface 'ppp0'
         native = self._tabs(
             """package network
 
-config interface 'ppp0'
+config interface 'custom_if0'
     option device '/dev/usb/modem1'
-    option ifname 'ppp0'
+    option ifname 'custom_if0'
     option ipv6 '1'
     option keepalive '3'
-    option password 'pwd0123'
-    option proto 'ppp'
-    option username 'user1'
+    option proto 'custom'
 """
         )
         expected = {
             "interfaces": [
                 {
-                    "name": "ppp0",
+                    "name": "custom_if0",
                     "type": "other",
-                    "proto": "ppp",
+                    "proto": "custom",
                     "device": "/dev/usb/modem1",
-                    "username": "user1",
-                    "password": "pwd0123",
                     "keepalive": '3',
                     "ipv6": '1',
                 }


### PR DESCRIPTION
These are useful for protocols like ppp, pppoe, pppoa, etc.:

https://wiki.openwrt.org/doc/uci/network#protocol_ppp_ppp_over_modem