### PR TITLE
WIP: Add support for firewall configuration to the OpenWrt backend

### DIFF
--- a/netjsonconfig/backends/openwrt/converters/__init__.py
+++ b/netjsonconfig/backends/openwrt/converters/__init__.py
@@ -9,8 +9,9 @@ from .routes import Routes
 from .rules import Rules
 from .switch import Switch
 from .wireless import Wireless
+from .firewall import Firewall
 
 __all__ = ['Default', 'Interfaces', 'General',
            'Led', 'Ntp', 'OpenVpn', 'Radios',
            'Routes', 'Rules', 'Switch',
-           'Wireless']
+           'Wireless', 'Firewall']

--- a/netjsonconfig/backends/openwrt/converters/firewall.py
+++ b/netjsonconfig/backends/openwrt/converters/firewall.py
@@ -1,0 +1,89 @@
+from collections import OrderedDict
+
+from ..schema import schema
+from .base import OpenWrtConverter
+
+
+class Firewall(OpenWrtConverter):
+    netjson_key = 'firewall'
+    intermediate_key = 'firewall'
+    _uci_types = ['defaults', 'forwarding', 'zone', 'rule']
+    _schema = schema['properties']['firewall']
+
+    def to_intermediate_loop(self, block, result, index=None):
+        forwardings = self.__intermediate_forwardings(block.pop('forwardings', {}))
+        zones = self.__intermediate_zones(block.pop('zones', {}))
+        rules = self.__intermediate_rules(block.pop('rules', {}))
+        block.update({
+            '.type': 'defaults',
+            '.name': block.pop('id', 'defaults'),
+        })
+        result.setdefault('firewall', [])
+        result['firewall'] = [self.sorted_dict(block)] + forwardings + zones + rules
+        return result
+
+    def __intermediate_forwardings(self, forwardings):
+        """
+        converts NetJSON forwarding to
+        UCI intermediate data structure
+        """
+        result = []
+        for forwarding in forwardings:
+            resultdict = OrderedDict((('.name', self.__get_auto_name_forwarding(forwarding)),
+                                      ('.type', 'forwarding')))
+            resultdict.update(forwarding)
+            result.append(resultdict)
+        return result
+
+    def __get_auto_name_forwarding(self, forwarding):
+        if 'family' in forwarding.keys():
+            uci_name = self._get_uci_name('_'.join([forwarding['src'], forwarding['dest'],
+                                          forwarding['family']]))
+        else:
+            uci_name = self._get_uci_name('_'.join([forwarding['src'], forwarding['dest']]))
+        return 'forwarding_{0}'.format(uci_name)
+
+    def __intermediate_zones(self, zones):
+        """
+        converts NetJSON zone to
+        UCI intermediate data structure
+        """
+        result = []
+        for zone in zones:
+            resultdict = OrderedDict((('.name', self.__get_auto_name_zone(zone)),
+                                      ('.type', 'zone')))
+            resultdict.update(zone)
+            result.append(resultdict)
+        return result
+
+    def __get_auto_name_zone(self, zone):
+        return 'zone_{0}'.format(self._get_uci_name(zone['name']))
+
+    def __intermediate_rules(self, rules):
+        """
+        converts NetJSON rule to
+        UCI intermediate data structure
+        """
+        result = []
+        for rule in rules:
+            if 'config_name' in rule:
+                del rule['config_name']
+            resultdict = OrderedDict((('.name', self.__get_auto_name_rule(rule)),
+                                      ('.type', 'rule')))
+            resultdict.update(rule)
+            result.append(resultdict)
+        return result
+
+    def __get_auto_name_rule(self, rule):
+        return 'rule_{0}'.format(self._get_uci_name(rule['name']))
+
+    def to_netjson_loop(self, block, result, index):
+        result['firewall'] = self.__netjson_firewall(block)
+        return result
+
+    def __netjson_firewall(self, firewall):
+        del firewall['.type']
+        _name = firewall.pop('.name')
+        if _name != 'firewall':
+            firewall['id'] = _name
+        return self.type_cast(firewall)

--- a/netjsonconfig/backends/openwrt/openwrt.py
+++ b/netjsonconfig/backends/openwrt/openwrt.py
@@ -21,6 +21,7 @@ class OpenWrt(BaseBackend):
         converters.Radios,
         converters.Wireless,
         converters.OpenVpn,
+        converters.Firewall,
         converters.Default,
     ]
     parser = OpenWrtParser

--- a/tests/openwrt/test_default.py
+++ b/tests/openwrt/test_default.py
@@ -20,42 +20,44 @@ class TestDefault(unittest.TestCase, _TabsMixin):
                     "boolean": True
                 }
             ],
-            "firewall": [
-                {
-                    "config_name": "rule",
-                    "name": "Allow-MLD",
-                    "src": "wan",
-                    "proto": "icmp",
-                    "src_ip": "fe80::/10",
-                    "family": "ipv6",
-                    "target": "ACCEPT",
-                    "icmp_type": [
-                        "130/0",
-                        "131/0",
-                        "132/0",
-                        "143/0"
-                    ]
-                },
-                {
-                    "config_name": "rule",
-                    "name": "Rule2",
-                    "src": "wan",
-                    "proto": "icmp",
-                    "src_ip": "192.168.1.1/24",
-                    "family": "ipv4",
-                    "target": "ACCEPT",
-                    "icmp_type": [
-                        "130/0",
-                        "131/0",
-                        "132/0",
-                        "143/0"
-                    ]
-                }
-            ]
+            "firewall": {
+                "rules": [
+                    {
+                        "config_name": "rule",
+                        "name": "Allow-MLD",
+                        "src": "wan",
+                        "proto": "icmp",
+                        "src_ip": "fe80::/10",
+                        "family": "ipv6",
+                        "target": "ACCEPT",
+                        "icmp_type": [
+                            "130/0",
+                            "131/0",
+                            "132/0",
+                            "143/0"
+                        ]
+                    },
+                    {
+                        "config_name": "rule",
+                        "name": "Rule2",
+                        "src": "wan",
+                        "proto": "icmp",
+                        "src_ip": "192.168.1.1/24",
+                        "family": "ipv4",
+                        "target": "ACCEPT",
+                        "icmp_type": [
+                            "130/0",
+                            "131/0",
+                            "132/0",
+                            "143/0"
+                        ]
+                    }
+                ]
+            }
         })
         expected = self._tabs("""package firewall
 
-config rule 'rule_1'
+config rule 'rule_Allow_MLD'
     option family 'ipv6'
     list icmp_type '130/0'
     list icmp_type '131/0'
@@ -67,7 +69,7 @@ config rule 'rule_1'
     option src_ip 'fe80::/10'
     option target 'ACCEPT'
 
-config rule 'rule_2'
+config rule 'rule_Rule2'
     option family 'ipv4'
     list icmp_type '130/0'
     list icmp_type '131/0'
@@ -148,18 +150,20 @@ config custom 'custom'
                     "boolean": "1"
                 }
             ],
-            "firewall": [
-                {
-                    "config_name": "rule",
-                    "name": "Allow-MLD",
-                    "src": "wan",
-                    "proto": "icmp",
-                    "src_ip": "fe80::/10",
-                    "family": "ipv6",
-                    "target": "ACCEPT",
-                    "icmp_type": ["130/0", "131/0", "132/0", "143/0"]
-                }
-            ],
+            "firewall": {
+                "rules": [
+                    {
+                        "config_name": "rule",
+                        "name": "Allow-MLD",
+                        "src": "wan",
+                        "proto": "icmp",
+                        "src_ip": "fe80::/10",
+                        "family": "ipv6",
+                        "target": "ACCEPT",
+                        "icmp_type": ["130/0", "131/0", "132/0", "143/0"]
+                    }
+                ]
+            },
             "led": [
                 {
                     "name": "USB1",


### PR DESCRIPTION
This PR adds support for the firewall configuration to the OpenWRT backend:

https://openwrt.org/docs/guide-user/firewall/firewall_configuration

Todos:

* [x] add rules
* [ ] finish converters
* [ ] add tests
* [ ] add documentation