### PR TITLE
[openwrt] Fixed TypeError caused by type mismatch

### DIFF
--- a/netjsonconfig/backends/openvpn/parser.py
+++ b/netjsonconfig/backends/openvpn/parser.py
@@ -4,8 +4,8 @@ import tarfile
 from ...utils import sorted_dict
 from ..base.parser import BaseParser
 
-vpn_pattern = re.compile('^# openvpn config:\s', flags=re.MULTILINE)
-config_pattern = re.compile('^([^\s]*) ?(.*)$')
+vpn_pattern = re.compile(r'^# openvpn config:\s', flags=re.MULTILINE)
+config_pattern = re.compile(r'^([^\s]*) ?(.*)$')
 config_suffix = '.conf'
 
 

--- a/netjsonconfig/backends/openwrt/converters/interfaces.py
+++ b/netjsonconfig/backends/openwrt/converters/interfaces.py
@@ -256,6 +256,10 @@ class Interfaces(OpenWrtConverter):
             netmask = interface.pop('netmask', 32)
             parsed_ip = self.__netjson_parse_ip(ipv4, netmask)
             ipv4 = [parsed_ip] if parsed_ip else []
+        if not isinstance(ipv6, list):
+            netmask = interface.pop('netmask', 128)
+            parsed_ip = self.__netjson_parse_ip(ipv6, netmask)
+            ipv6 = [parsed_ip] if parsed_ip else []
         if proto.startswith('dhcp'):
             family = 'ipv4' if proto == 'dhcp' else 'ipv6'
             addresses.append({'proto': 'dhcp', 'family': family})

--- a/netjsonconfig/backends/openwrt/parser.py
+++ b/netjsonconfig/backends/openwrt/parser.py
@@ -5,9 +5,9 @@ from collections import OrderedDict
 from ...utils import sorted_dict
 from ..base.parser import BaseParser
 
-packages_pattern = re.compile('^package\s', flags=re.MULTILINE)
-block_pattern = re.compile('^config\s', flags=re.MULTILINE)
-config_pattern = re.compile('^(option|list)\s*([^\s]*)\s*(.*)')
+packages_pattern = re.compile(r'^package\s', flags=re.MULTILINE)
+block_pattern = re.compile(r'^config\s', flags=re.MULTILINE)
+config_pattern = re.compile(r'^(option|list)\s*([^\s]*)\s*(.*)')
 config_path = 'etc/config/'
 
 

--- a/tests/openwrt/test_backend.py
+++ b/tests/openwrt/test_backend.py
@@ -69,7 +69,7 @@ class TestBackend(unittest.TestCase, _TabsMixin):
         with self.assertRaises(TypeError):
             OpenWrt([])
         with self.assertRaises(TypeError):
-            OpenWrt('NOTJSON[]\{\}')
+            OpenWrt(r'NOTJSON[]\{\}')
 
     def test_system_invalid_timezone(self):
         o = OpenWrt({


### PR DESCRIPTION
This should resolve issue #118.

I've fixed a TypeError that was raised due to a concatenation (`ipv4 + ipv6`) between two addresses that were of different types, `list` and `str`. I resolved this by applying the same type conversion that was applied to the `ipv4` variable: If only one address is found, convert it to a list of a single element.

After looking through the error traceback that was provided in the issue, it didn't take long to find out what the problem was caused by: When only one ipv6 address is found, the type of the `ipv6` variable is `str`. However, later in the method, the variable is added to the `ipv4` element:
```python
for address in ipv4 + ipv6:
```
`ipv4` will always be a list, as shown by the type conversion that was applied before mine:
```python
if not isinstance(ipv4, list):
    netmask = interface.pop('netmask', 32)
    parsed_ip = self.__netjson_parse_ip(ipv4, netmask)
    ipv4 = [parsed_ip] if parsed_ip else []
```
As far as I understand it, the same logic can be used for the conversion for `ipv6`, by changing the `32` to `128` (there are 128 bits to an ipv6 address, as opposed to the 32 assigned for an ipv4 address):
```python
if not isinstance(ipv6, list):
    netmask = interface.pop('netmask', 128)
    parsed_ip = self.__netjson_parse_ip(ipv6, netmask)
    ipv6 = [parsed_ip] if parsed_ip else []
```
Let me know if there's a flaw in my logic, but this is what I have implemented for the solution to this issue. 