### PR TITLE
[openwisp-controller][bug] Allow multiple VPNs with same CA & Cert 

### DIFF
--- a/netjsonconfig/schema.py
+++ b/netjsonconfig/schema.py
@@ -1034,7 +1034,7 @@ schema = {
         "files": {
             "type": "array",
             "title": "Files",
-            "uniqueItems": True,
+            "uniqueItems": False,
             "additionalItems": True,
             "propertyOrder": 20,
             "items": {


### PR DESCRIPTION
Reusing the same CA and Cert certificate in 2 VPNs and activating both on a device triggers a validation error in netjsonconfig.
Setting `uniqueItems` as `False` will set `self.schema['properties']['files']['uniqueItems'] = False` allowing multiple VPNs with same CA & Cert files.

Closes https://github.com/openwisp/openwisp-controller/issues/65