### PR TITLE
[qa] Install flake8 and isort via openwisp-utils[qa]

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,9 +1,7 @@
 nose
 coverage
 coveralls
-isort
-flake8
 sphinx
 sphinx_rtd_theme
 # commit message style check
-openwisp-utils>=0.2.1
+openwisp-utils[qa]>=0.2.1


### PR DESCRIPTION
Install `flake8` and `isort` via `openwisp-utils[qa]`.