### PR TITLE
[ci] Implicitly get coverage version from coveralls

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 nose2[coverage_plugin]>=0.6.5
-coverage
 coveralls
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
The coveralls package already has a dependency on coverage
and sets the boundary according to its support for the coverage library.
We should not duplicate this information.