### PR TITLE
[x509] Added dedicated file mode for generated x509 certificates #147

### DIFF
--- a/netjsonconfig/backends/openvpn/openvpn.py
+++ b/netjsonconfig/backends/openvpn/openvpn.py
@@ -1,4 +1,4 @@
-from ...schema import DEFAULT_FILE_MODE
+from ...schema import X509_FILE_MODE
 from ..base.backend import BaseBackend
 from . import converters
 from .parser import OpenVpnParser, config_suffix, vpn_pattern
@@ -121,15 +121,15 @@ class OpenVpn(BaseBackend):
             client['ca'] = ca_path
             files.append(dict(path=ca_path,
                               contents=ca_contents,
-                              mode=DEFAULT_FILE_MODE))
+                              mode=X509_FILE_MODE))
         if cert_path and cert_contents:
             client['cert'] = cert_path
             files.append(dict(path=cert_path,
                               contents=cert_contents,
-                              mode=DEFAULT_FILE_MODE))
+                              mode=X509_FILE_MODE))
         if key_path and key_contents:
             client['key'] = key_path
             files.append(dict(path=key_path,
                               contents=key_contents,
-                              mode=DEFAULT_FILE_MODE,))
+                              mode=X509_FILE_MODE,))
         return files

--- a/netjsonconfig/schema.py
+++ b/netjsonconfig/schema.py
@@ -7,6 +7,7 @@ from .channels import channels_2and5, channels_2ghz, channels_5ghz
 from .countries import countries
 
 DEFAULT_FILE_MODE = '0644'
+X509_FILE_MODE = '0600'
 MAC_PATTERN = '([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})'
 MAC_PATTERN_BLANK = '^({0}|)$'.format(MAC_PATTERN)
 

--- a/tests/openvpn/test_backend.py
+++ b/tests/openvpn/test_backend.py
@@ -586,17 +586,17 @@ tls-client
 # ---------- files ---------- #
 
 # path: {{ca_path_1}}
-# mode: 0644
+# mode: 0600
 
 {{ca_contents_1}}
 
 # path: {{cert_path_1}}
-# mode: 0644
+# mode: 0600
 
 {{cert_contents_1}}
 
 # path: {{key_path_1}}
-# mode: 0644
+# mode: 0600
 
 {{key_contents_1}}
 

--- a/tests/openwisp/test_backend.py
+++ b/tests/openwisp/test_backend.py
@@ -107,12 +107,12 @@ class TestBackend(unittest.TestCase, _TabsMixin):
         "files": [
             {
                 "path": "/openvpn/x509/ca_1_service.pem",
-                "mode": "0644",
+                "mode": "0600",
                 "contents": "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n"  # noqa
             },
             {
                 "path": "/openvpn/x509/l2vpn_client_2693.pem",
-                "mode": "0644",
+                "mode": "0600",
                 "contents": "-----BEGIN CERTIFICATE-----\ntest==\n-----END CERTIFICATE-----\n-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n"  # noqa
             }
         ]


### PR DESCRIPTION
OpenVPN certificate files will have `0600` default permission.
Modified tests for same.
Related https://github.com/openwisp/django-netjsonconfig/issues/169
Closes #147