### PR TITLE
[bug] Fix switch vlan ordering #104

### DIFF
--- a/netjsonconfig/backends/base/converter.py
+++ b/netjsonconfig/backends/base/converter.py
@@ -92,8 +92,8 @@ class BaseConverter(object):
         to a NetJSON configuration dictionary (``self.config``)
         """
         result = OrderedDict()
-        # copy list
-        intermediate_data = list(self.intermediate_data[self.intermediate_key])
+        # Clean intermediate data
+        intermediate_data = self.clean_intermediate_data(list(self.intermediate_data[self.intermediate_key]))
         # iterate over copied intermediate data structure
         for index, block in enumerate(intermediate_data):
             if self.should_skip_block(block):
@@ -108,6 +108,19 @@ class BaseConverter(object):
             result = self.to_netjson_loop(block, result, index + 1)
         # return result, expects dict
         return result
+
+    def clean_intermediate_data(self, intermediate_data):
+        """
+        Utility method called to clean data for backend in ``to_netjson``
+        """
+        clean_intermediate_data, appendto_clean_intermediate_data = [], []
+        for block in intermediate_data:
+            if '.type' in block and block['.type'] == 'switch_vlan':
+                appendto_clean_intermediate_data.append(block)
+            else:
+                clean_intermediate_data.append(block)
+        clean_intermediate_data.extend(appendto_clean_intermediate_data)
+        return clean_intermediate_data
 
     def to_netjson_loop(self, block, result, index=None):  # pragma: nocover
         """

--- a/tests/openwrt/test_network.py
+++ b/tests/openwrt/test_network.py
@@ -284,6 +284,37 @@ config switch_vlan 'v1'
     option vlan '3'
 """
 
+    _switch_uci_reorder = """package network
+
+config switch_vlan 'switch0_vlan1'
+    option device 'switch0'
+    option ports '0t 2 3 4 5'
+    option vid '1'
+    option vlan '1'
+
+config switch 'switch0'
+    option enable_vlan '1'
+    option name 'switch0'
+    option reset '1'
+"""
+
+    _switch_netjson_reorder = {
+        "switch": [
+            {
+                "name": "switch0",
+                "reset": True,
+                "enable_vlan": True,
+                "vlan": [
+                    {
+                        "device": "switch0",
+                        "vlan": 1,
+                        "ports": "0t 2 3 4 5"
+                    }
+                ]
+            }
+        ]
+    }
+
     def test_render_switch(self):
         o = OpenWrt(self._switch_netjson)
         expected = self._tabs(self._switch_uci)
@@ -292,3 +323,7 @@ config switch_vlan 'v1'
     def test_parse_switch(self):
         o = OpenWrt(native=self._switch_uci)
         self.assertEqual(o.config, self._switch_netjson)
+
+    def test_parse_switch_reorder(self):
+        o = OpenWrt(native=self._switch_uci_reorder)
+        self.assertEqual(o.config, self._switch_netjson_reorder)


### PR DESCRIPTION
I found that the issue #104 is because the order of the list items is causing problems, `switch_vlan` is defined and processed before `switch` which is causing `KeyError` as switch itself is not existing at the time `switch_vlan` is being processed.

This pull request solves the problem by reordering the intermediate list.

Closes #104


Please let me know if there is a better way to solve this issue! 