### PR TITLE
[fix] Openwrt backend validation problem for property ip_rules/src #96

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ target/
 
 # editors
 *.komodoproject
+.vscode
 
 # other
 *.DS_Store*

--- a/netjsonconfig/backends/base/backend.py
+++ b/netjsonconfig/backends/base/backend.py
@@ -1,4 +1,5 @@
 import gzip
+import ipaddress
 import json
 import tarfile
 from collections import OrderedDict
@@ -121,6 +122,14 @@ class BaseBackend(object):
         for file in files:
             files_dict[file['path']] = file
         self.config['files'] = list(files_dict.values())
+
+    @draft4_format_checker.checks('cidr', AssertionError)
+    def _cidr_notation(value):
+        try:
+            ipaddress.ip_network(value)
+        except ValueError as e:
+            assert False, str(e)
+        return True
 
     def validate(self):
         try:

--- a/netjsonconfig/backends/openwrt/schema.py
+++ b/netjsonconfig/backends/openwrt/schema.py
@@ -229,12 +229,14 @@ schema = merge_config(
                             "title": "source subnet",
                             "description": "(CIDR notation)",
                             "propertyOrder": 3,
+                            "format": "cidr",
                         },
                         "dest": {
                             "type": "string",
                             "title": "destination subnet",
                             "description": "(CIDR notation)",
                             "propertyOrder": 4,
+                            "format": "cidr",
                         },
                         "tos": {
                             "type": "integer",

--- a/tests/openwrt/test_network.py
+++ b/tests/openwrt/test_network.py
@@ -210,6 +210,61 @@ config rule 'rule1'
         )
         self.assertEqual(o.render(), expected)
 
+    def test_render_rule_wrong(self):
+        rule = {
+            "ip_rules": [
+                {
+                    "in": "eth0",
+                    "out": "eth1",
+                    "src": "wrong",
+                    "dest": "wrong",
+                    "tos": 2,
+                    "action": "blackhole"
+                }
+            ]
+        }
+        o = OpenWrt(rule)
+        try:
+            o.validate()
+        except ValidationError as e:
+            # check error message
+            pass
+        else:
+            self.fail('ValidationError not raised')
+        # fix 'src' and expect wrong 'dest' to fail
+        rule['src'] = '192.168.1.1/24'
+        o = OpenWrt(rule)
+        try:
+            o.validate()
+        except ValidationError as e:
+            # check error message
+            pass
+        else:
+            self.fail('ValidationError not raised')
+        # fix 'dest' and expect no ValidationError raised
+        rule['src'] = '192.168.1.1/24'
+        o = OpenWrt(rule)
+        o.validate()
+
+    def test_parse_rules_zone(self):
+        o = OpenWrt(native="""package network
+
+config rule 'rule1'
+    option action 'blackhole'
+    option dest 'wrong'
+    option in 'eth0'
+    option out 'eth1'
+    option src 'wrong'
+    option tos '2'
+""")
+        try:
+            o.validate()
+        except ValidationError as e:
+            # check error message
+            pass
+        else:
+            self.fail('ValidationError not raised')
+
     _switch_netjson = {
         "switch": [
             {


### PR DESCRIPTION
Fixed the issue by adding a pattern to match the valid src and dest notation.

Fixes #96