### PR TITLE
[netjsonconfig-tests] Avoid error logging to print noisy output durin…

### DIFF
--- a/tests/openwrt/test_default.py
+++ b/tests/openwrt/test_default.py
@@ -1,5 +1,7 @@
 import unittest
 
+from openwisp_utils.tests import capture_stdout
+
 from netjsonconfig import OpenWrt
 from netjsonconfig.utils import _TabsMixin
 
@@ -176,6 +178,7 @@ config custom 'custom'
         o = OpenWrt({"skipme": {"enabled": True}})
         self.assertEqual(o.render(), '')
 
+    @capture_stdout()
     def test_warning(self):
         o = OpenWrt({"luci": [{"unrecognized": True}]})
         self.assertEqual(o.render(), '')


### PR DESCRIPTION
…g tests #150

Applied `capture_stdout` decorator on noisy tests

Fixes #150