### PR TITLE
[openvpn] Remove mandatory items

### DIFF
--- a/netjsonconfig/backends/openvpn/schema.py
+++ b/netjsonconfig/backends/openvpn/schema.py
@@ -12,7 +12,7 @@ base_openvpn_schema = {
     "definitions": {
         "tunnel": {
             "type": "object",
-            "required": ["name", "mode", "proto", "dev"],
+            "required": ["name"],
             "properties": {
                 "name": {
                     "title": "name",
@@ -475,7 +475,6 @@ base_openvpn_schema = {
                 {"$ref": "#/definitions/tunnel"},
                 {
                     "type": "object",
-                    "required": ["remote"],
                     "properties": {
                         "mode": {"enum": ["p2p"]},
                         "proto": {
@@ -791,7 +790,7 @@ base_openvpn_schema = {
                 "type": "object",
                 "title": "VPN",
                 "additionalProperties": True,
-                "oneOf": [
+                "anyOf": [
                     {"$ref": "#/definitions/client"},
                     {"$ref": "#/definitions/server_manual"},
                     {"$ref": "#/definitions/server_bridged"},


### PR DESCRIPTION
In certain situations, especially when modifying an existing openvpn config, it shouldn't be necessary to provide certain items as they might already exist in the openvpn config.