### PR TITLE
[openwrt] Fix the EAP protocol notation

### DIFF
--- a/netjsonconfig/schema.py
+++ b/netjsonconfig/schema.py
@@ -543,7 +543,7 @@ schema = {
                             "title": "EAP protocol",
                             "type": "string",
                             "enum": ["tls", "ttls"],
-                            "options": {"enum_titles": ["EAP-TLS", "EAP-PEAP"]},
+                            "options": {"enum_titles": ["EAP-TLS", "EAP-TTLS"]},
                             "propertyOrder": 4,
                         },
                         "identity": {"type": "string", "propertyOrder": 5},


### PR DESCRIPTION
Corrected the notation because it was showing ```EAP-PEAP``` even though ```TTLS``` was set for ```OpenWrt```.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>