### PR TITLE
[chores] Fixed ReadTheDocs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -208,53 +208,6 @@ html_static_path = []
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'netjsonconfigdoc'
 
-# -- Options for LaTeX output ---------------------------------------------
-
-latex_elements = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #'papersize': 'letterpaper',
-    # The font size ('10pt', '11pt' or '12pt').
-    #'pointsize': '10pt',
-    # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
-    # Latex figure (float) alignment
-    #'figure_align': 'htbp',
-}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (
-        master_doc,
-        'netjsonconfig.tex',
-        u'netjsonconfig documentation',
-        u'Federico Capoano',
-        'manual',
-    ),
-]
-
-# The name of an image file (relative to this directory) to place at the top of
-# the title page.
-# latex_logo = None
-
-# For "manual" documents, if this is true, then toplevel headings are parts,
-# not chapters.
-# latex_use_parts = False
-
-# If true, show page references after internal links.
-# latex_show_pagerefs = False
-
-# If true, show URL addresses after external links.
-# latex_show_urls = False
-
-# Documents to append as an appendix to all manuals.
-# latex_appendices = []
-
-# If false, no module index is generated.
-# latex_domain_indices = True
-
-
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples


### PR DESCRIPTION
ReadTheDocs build was failing because latex does not
support nested tables that is used in backends/wireguard.rst

Closes https://github.com/openwisp/netjsonconfig/issues/211