### PR TITLE
Add missing WiFi 5GHz / 802.11ac channels on U-NII-2C and U-NII-3 (Closes #233)

### DIFF
--- a/netjsonconfig/channels.py
+++ b/netjsonconfig/channels.py
@@ -3,6 +3,6 @@ wifi channels
 """
 
 channels_2ghz = list(range(0, 14))
-channels_5ghz = list(range(36, 68, 4)) + list(range(100, 144, 4))
+channels_5ghz = list(range(36, 68, 4)) + list(range(100, 148, 4)) + list(range(149, 181, 4))
 channels_2and5 = list(channels_2ghz + channels_5ghz)
 channels_5ghz.insert(0, 0)

--- a/netjsonconfig/channels.py
+++ b/netjsonconfig/channels.py
@@ -3,6 +3,8 @@ wifi channels
 """
 
 channels_2ghz = list(range(0, 14))
-channels_5ghz = list(range(36, 68, 4)) + list(range(100, 148, 4)) + list(range(149, 181, 4))
+channels_5ghz = (
+    list(range(36, 68, 4)) + list(range(100, 148, 4)) + list(range(149, 181, 4))
+)
 channels_2and5 = list(channels_2ghz + channels_5ghz)
 channels_5ghz.insert(0, 0)


### PR DESCRIPTION
- 36 to 64, increments of 4 (U-NII-1 + U-NII-2A), as is
- 100 to 144, increments of 4 (U-NII-2C), instead of up to 140
- 149 to 177, increments of 4 (U-NII-3 + U-NII-4), entirely missing

#233