### PR TITLE
[change] Updated default values for parameters OpenVpn.auto_client #240

### DIFF
--- a/netjsonconfig/backends/openvpn/openvpn.py
+++ b/netjsonconfig/backends/openvpn/openvpn.py
@@ -105,10 +105,8 @@ class OpenVpn(BaseVpnBackend):
             'persist_tun',
             'mute',
             'persist_key',
-            'script_security',
             'user',
             'group',
-            'log',
             'mute_replay_warnings',
             'secret',
             'reneg_sec',
@@ -122,6 +120,14 @@ class OpenVpn(BaseVpnBackend):
         for key in copy_keys:
             if key in server:
                 client[key] = server[key]
+        if 'script_security' in server:
+            # From OpenWrt 21 onwards, "script_security" of "2"
+            # is required for functioning of OpenVPN tunnels.
+            client['script_security'] = 2
+        if 'log' in server:
+            # The "/var/log/openvpn" directory is not present
+            # on OpenWrt, hence the location of the log is changed.
+            client['log'] = server['log'].replace('/var/log/openvpn/', '/var/log/')
         files = cls._auto_client_files(
             client,
             ca_path,

--- a/tests/openvpn/test_backend.py
+++ b/tests/openvpn/test_backend.py
@@ -595,6 +595,8 @@ tls-client
             "engine": "dynamic",
             "ns_cert_type": "client",
             "server_bridge": "",
+            "script_security": 1,
+            "log": "/var/log/openvpn/tap0.log",
         }
         client_config = OpenVpn.auto_client(
             'vpn1.test.com',
@@ -617,6 +619,7 @@ comp-lzo yes
 dev tap0
 dev-type tap
 key {{key_path_1}}
+log /var/log/tap0.log
 mode p2p
 nobind
 ns-cert-type server
@@ -624,6 +627,7 @@ proto tcp-client
 pull
 remote vpn1.test.com 1195
 resolv-retry infinite
+script-security 2
 tls-client
 
 # ---------- files ---------- #


### PR DESCRIPTION
The client configuration generated by OpenVpn.autoclient will have "script_security" set to "2" and "log" set to "/var/log/<ifname>.log".

Closes #240