### PR TITLE
[fix] Fixed wrong network name in wireless interface #249

### DIFF
--- a/netjsonconfig/backends/openwrt/converters/wireless.py
+++ b/netjsonconfig/backends/openwrt/converters/wireless.py
@@ -375,8 +375,8 @@ class Wireless(OpenWrtConverter):
                 # Bridge is empty.
                 continue
             bridge_name = interface['.name']
-            if self.dsa:
-                bridge_name = bridge_name.lstrip('device_')
+            if self.dsa and bridge_name.startswith('device_'):
+                bridge_name = bridge_name[len('device_') :]  # noqa
             for physical_interface in bridge_members:
                 # A physical interface can be a member of multiple
                 # bridges. Hence, we create a list of bridge interfaces


### PR DESCRIPTION
- Removed `str.lstrip()` for getting `bridge_name` since the **lstrip()** arguments are not a prefix; rather, all combinations of their values are stripped that results in incorrect name.

Ref : https://docs.python.org/3/library/stdtypes.html#str.lstrip

Fixes #249