### PR TITLE
[fix] Fixed unashable type list error in merge_list

### DIFF
--- a/netjsonconfig/utils.py
+++ b/netjsonconfig/utils.py
@@ -68,6 +68,10 @@ def merge_list(list1, list2, identifiers=None):
                     if id_key in el:
                         key = el[id_key]
                         break
+            # if key is a list, convert it to tuple which is
+            # hashable and can be used as a dictionary key
+            if isinstance(key, list):
+                key = tuple(key)
             container[key] = deepcopy(el)
         counter += 1
     merged = merge_config(dict_map['list1'], dict_map['list2'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -147,3 +147,9 @@ class TestUtils(unittest.TestCase):
         ]
         result = merge_list(conf1, conf2)
         self.assertEqual(result, conf2)
+
+    def test_merge_list_unashable_type(self):
+        conf1 = [{"name": ["walledgarden"], "contents": ""}]
+        conf2 = [{"name": ["walledgarden"], "contents": "test"}]
+        result = merge_list(conf1, conf2, identifiers=['name'])
+        self.assertEqual(result, conf2)


### PR DESCRIPTION
In some cases it's possible that a list may be used as the key of a dictionary, which would raise an exception because python lists are not hashable. Therefore, when this happens, we need to convert the list to tuple, which can be hashed.