### PR TITLE
[change] OpenWrt: hide roaming UCI if roaming disabled

### DIFF
--- a/netjsonconfig/backends/openwrt/converters/wireless.py
+++ b/netjsonconfig/backends/openwrt/converters/wireless.py
@@ -61,6 +61,7 @@ class Wireless(OpenWrtConverter):
         if 'encryption' in wireless:
             encryption = self.__intermediate_encryption(wireless)
             wireless.update(encryption)
+        wireless = self.__intermediate_roaming(wireless)
         # attached networks (openwrt specific)
         # by default the wifi interface is attached
         # to its defining interface
@@ -138,6 +139,20 @@ class Wireless(OpenWrtConverter):
         if cipher and protocol.startswith('wpa') and cipher != 'auto':
             uci['encryption'] += '+{0}'.format(cipher)
         return uci
+
+    roaming_properties = (
+        'ft_over_ds',
+        'ft_psk_generate_local',
+        'nasid',
+        'reassociation_deadline',
+    )
+
+    def __intermediate_roaming(self, wireless):
+        if wireless.get('ieee80211r') is False:
+            for property in self.roaming_properties:
+                if property in wireless:
+                    del wireless[property]
+        return wireless
 
     def to_netjson_loop(self, block, result, index):
         is_new = False

--- a/tests/openwrt/test_wireless.py
+++ b/tests/openwrt/test_wireless.py
@@ -861,6 +861,52 @@ config wifi-iface 'wifi_wlan0'
             del netjson_80211r['interfaces'][0]['wireless']['reassociation_deadline']
             self.assertEqual(o.config, netjson_80211r)
 
+    _80211r_false_netjson = {
+        "interfaces": [
+            {
+                "name": "wlan0",
+                "type": "wireless",
+                "wireless": {
+                    "radio": "radio0",
+                    "mode": "access_point",
+                    "ssid": "MyWifiAP",
+                    "rsn_preauth": True,
+                    "ieee80211r": False,
+                    "ft_over_ds": True,
+                    "ft_psk_generate_local": True,
+                    "nasid": "123",
+                    "reassociation_deadline": 1000,
+                    "network": ["lan"],
+                },
+            }
+        ]
+    }
+    _80211r_false_uci = """package network
+
+config device 'device_wlan0'
+    option name 'wlan0'
+
+config interface 'wlan0'
+    option device 'wlan0'
+    option proto 'none'
+
+package wireless
+
+config wifi-iface 'wifi_wlan0'
+    option device 'radio0'
+    option ieee80211r '0'
+    option ifname 'wlan0'
+    option mode 'ap'
+    option network 'lan'
+    option rsn_preauth '1'
+    option ssid 'MyWifiAP'
+"""
+
+    def test_render_access_point_80211r_false(self):
+        o = OpenWrt(self._80211r_false_netjson)
+        expected = self._tabs(self._80211r_false_uci)
+        self.assertEqual(o.render(), expected)
+
     _80211s_netjson = {
         "interfaces": [
             {


### PR DESCRIPTION
If WiFI roaming (802.11r) is not enabled, do not generate the UCI config options in the wireless configuration.