### PR TITLE
[fix] Fixed optional management frame protection #264

### DIFF
--- a/netjsonconfig/schema.py
+++ b/netjsonconfig/schema.py
@@ -496,7 +496,7 @@ schema = {
                 "ieee80211w": {
                     "type": "string",
                     "title": "management frame protection",
-                    "enum": ["1"],
+                    "enum": ["1", "2"],
                     "readOnly": True,
                     "options": {"enum_titles": ["optional", "required"]},
                     "propertyOrder": 4,

--- a/tests/openwrt/test_encryption.py
+++ b/tests/openwrt/test_encryption.py
@@ -71,7 +71,7 @@ config wifi-iface 'wifi_wlan0'
                         "protocol": "wpa2_personal_mixed",
                         "cipher": "ccmp",
                         "key": "passphrase012345",
-                        "ieee80211w": "1",
+                        "ieee80211w": "2",
                     },
                 },
             }
@@ -91,7 +91,7 @@ package wireless
 config wifi-iface 'wifi_wlan0'
     option device 'radio0'
     option encryption 'sae-mixed+ccmp'
-    option ieee80211w '1'
+    option ieee80211w '2'
     option ifname 'wlan0'
     option key 'passphrase012345'
     option mode 'ap'


### PR DESCRIPTION
Closes #264

@pandafy this change here looks like a mistake, which I am fixing in this PR:

https://github.com/openwisp/netjsonconfig/commit/e696759a#diff-83e7f712c7b8a94dcf6a0acb84af4a1566db59ada5e3ecae57ab6f487ec93bd0L483-L485

The "optional" option was removed but  the corresponding "enum_titles" was not. However, the section in the schema is named "encryption_mfp_property_optional" so it doesn't make a lot of sense to remove the possibility of setting MFP to "optional".

Let me know if you think that was not a mistake and give us more explanation.