### PR TITLE
[change] OpenWrt: updated WPA enterprise settings #291

### DIFF
--- a/netjsonconfig/backends/openwrt/converters/wireless.py
+++ b/netjsonconfig/backends/openwrt/converters/wireless.py
@@ -144,9 +144,9 @@ class Wireless(OpenWrtConverter):
                 if option in encryption:
                     uci[f'auth_{option}'] = encryption[option]
             uci['auth_secret'] = encryption['key']
-            if not encryption.get('acct_secret'):
+            if 'acct_secret' not in encryption:
                 uci['acct_secret'] = encryption['key']
-            if encryption.get('acct_server_port'):
+            if 'acct_server_port' in encryption:
                 uci['acct_port'] = encryption.pop('acct_server_port')
 
     roaming_properties = (
@@ -338,14 +338,14 @@ class Wireless(OpenWrtConverter):
         if 'enterprise' in settings['protocol']:
             if 'auth_secret' in settings:
                 settings['key'] = settings.pop('auth_secret')
-            if settings.get('acct_secret') and settings['acct_secret'] == settings.get(
+            if 'acct_secret' in settings and settings['acct_secret'] == settings.get(
                 'key'
             ):
                 settings.pop('acct_secret')
             for option in ['server', 'port']:
                 if f'auth_{option}' in settings:
                     settings[option] = settings.pop(f'auth_{option}')
-            if settings.get('acct_port'):
+            if 'acct_port' in settings:
                 settings['acct_server_port'] = settings.pop('acct_port')
         # Management Frame Protection
         if 'ieee80211w' in wifi:

--- a/netjsonconfig/backends/openwrt/converters/wireless.py
+++ b/netjsonconfig/backends/openwrt/converters/wireless.py
@@ -110,7 +110,7 @@ class Wireless(OpenWrtConverter):
             return {'encryption': 'none'}
         # otherwise configure encryption
         uci = encryption.copy()
-        for option in ['protocol', 'key', 'cipher', 'disabled']:
+        for option in ['protocol', 'key', 'cipher', 'disabled', 'acct_server_port']:
             if option in uci:
                 del uci[option]
         protocol = encryption['protocol']
@@ -146,6 +146,8 @@ class Wireless(OpenWrtConverter):
             uci['auth_secret'] = encryption['key']
             if not encryption.get('acct_secret'):
                 uci['acct_secret'] = encryption['key']
+            if encryption.get('acct_server_port'):
+                uci['acct_port'] = encryption.pop('acct_server_port')
 
     roaming_properties = (
         'ft_over_ds',
@@ -343,6 +345,8 @@ class Wireless(OpenWrtConverter):
             for option in ['server', 'port']:
                 if f'auth_{option}' in settings:
                     settings[option] = settings.pop(f'auth_{option}')
+            if settings.get('acct_port'):
+                settings['acct_server_port'] = settings.pop('acct_port')
         # Management Frame Protection
         if 'ieee80211w' in wifi:
             settings['ieee80211w'] = wifi.pop('ieee80211w')
@@ -353,8 +357,8 @@ class Wireless(OpenWrtConverter):
         # type casting
         if 'port' in encryption:
             encryption['port'] = int(encryption['port'])
-        if 'acct_port' in encryption:
-            encryption['acct_port'] = int(encryption['acct_port'])
+        if 'acct_server_port' in encryption:
+            encryption['acct_server_port'] = int(encryption['acct_server_port'])
         if 'dae_port' in encryption:
             encryption['dae_port'] = int(encryption['dae_port'])
         if 'acct_interval' in encryption:

--- a/netjsonconfig/backends/openwrt/schema.py
+++ b/netjsonconfig/backends/openwrt/schema.py
@@ -704,6 +704,50 @@ schema = merge_config(
                     {"$ref": "#/definitions/radio_60g_band"},
                 ]
             },
+            "encryption_wpa_enterprise_ap_base_settings": {
+                "properties": {
+                    "acct_secret": {
+                        "title": "accounting shared secret",
+                        "type": "string",
+                        "propertyOrder": 9,
+                    },
+                    "acct_interval": {
+                        "type": "integer",
+                        "title": "accounting interval",
+                        "default": 600,
+                        "propertyOrder": 10,
+                    },
+                    "dae_client": {
+                        "title": "DAE client",
+                        "type": "string",
+                        "description": (
+                            "Dynamic Authorization Extension client."
+                            " This client can send \"Disconnect-Request\""
+                            " or \"CoA-Request\" packets to forcibly disconnect a client"
+                            " or change connection parameters."
+                        ),
+                        "propertyOrder": 11,
+                    },
+                    "dae_port": {
+                        "type": "integer",
+                        "title": "DAE port",
+                        # "description": "port the Dynamic Authorization Extension server listens on.",
+                        "default": 3799,
+                        "propertyOrder": 12,
+                    },
+                    "dae_secret": {
+                        "title": "DAE secret",
+                        "type": "string",
+                        "propertyOrder": 13,
+                    },
+                    "nasid": {
+                        "title": "NAS ID",
+                        "type": "string",
+                        "description": "NAS ID for RADIUS authentication requests",
+                        "propertyOrder": 13,
+                    },
+                }
+            },
         },
         "properties": {
             "general": {

--- a/tests/openwrt/test_encryption.py
+++ b/tests/openwrt/test_encryption.py
@@ -288,6 +288,9 @@ config interface 'wlan0'
 package wireless
 
 config wifi-iface 'wifi_wlan0'
+    option acct_secret 'radius_secret'
+    option auth_secret 'radius_secret'
+    option auth_server '192.168.0.1'
     option device 'radio0'
     option encryption 'wpa3-mixed+ccmp'
     option ieee80211w '1'
@@ -325,6 +328,10 @@ config wifi-iface 'wifi_wlan0'
                         "port": 1812,
                         "acct_server": "192.168.0.2",
                         "acct_port": 1813,
+                        "acct_interval": 300,
+                        "dae_client": "192.168.0.2",
+                        "dae_port": 3799,
+                        "dae_secret": "radius_secret",
                         "nasid": "2",
                         "wpa_group_rekey": "350",
                         "ieee80211w": "2",
@@ -345,8 +352,16 @@ config interface 'wlan0'
 package wireless
 
 config wifi-iface 'wifi_wlan0'
+    option acct_interval '300'
     option acct_port '1813'
+    option acct_secret 'radius_secret'
     option acct_server '192.168.0.2'
+    option auth_port '1812'
+    option auth_secret 'radius_secret'
+    option auth_server '192.168.0.1'
+    option dae_client '192.168.0.2'
+    option dae_port '3799'
+    option dae_secret 'radius_secret'
     option device 'radio0'
     option encryption 'wpa3+ccmp'
     option ieee80211w '2'
@@ -407,7 +422,11 @@ package wireless
 
 config wifi-iface 'wifi_wlan0'
     option acct_port '1813'
+    option acct_secret 'radius_secret'
     option acct_server '192.168.0.2'
+    option auth_port '1812'
+    option auth_secret 'radius_secret'
+    option auth_server '192.168.0.1'
     option device 'radio0'
     option encryption 'wpa2+tkip'
     option ifname 'wlan0'
@@ -461,6 +480,9 @@ config interface 'wlan0'
 package wireless
 
 config wifi-iface 'wifi_wlan0'
+    option acct_secret 'radius_secret'
+    option auth_secret 'radius_secret'
+    option auth_server '192.168.0.1'
     option device 'radio0'
     option encryption 'wpa-mixed'
     option ifname 'wlan0'
@@ -511,6 +533,9 @@ config interface 'wlan0'
 package wireless
 
 config wifi-iface 'wifi_wlan0'
+    option acct_secret 'radius_secret'
+    option auth_secret 'radius_secret'
+    option auth_server '192.168.0.1'
     option device 'radio0'
     option encryption 'wpa+ccmp'
     option ifname 'wlan0'

--- a/tests/openwrt/test_encryption.py
+++ b/tests/openwrt/test_encryption.py
@@ -383,9 +383,6 @@ config wifi-iface 'wifi_wlan0'
 
     def test_parse_wpa3_enterprise(self):
         o = OpenWrt(native=self._wpa3_enterprise_ap_uci)
-        from pprint import pprint
-
-        pprint(dict(o.config))
         self.assertEqual(o.config, self._wpa3_enterprise_ap_netjson)
 
     _wpa2_enterprise_ap_netjson = {

--- a/tests/openwrt/test_encryption.py
+++ b/tests/openwrt/test_encryption.py
@@ -327,7 +327,7 @@ config wifi-iface 'wifi_wlan0'
                         "server": "192.168.0.1",
                         "port": 1812,
                         "acct_server": "192.168.0.2",
-                        "acct_port": 1813,
+                        "acct_server_port": 1813,
                         "acct_interval": 300,
                         "dae_client": "192.168.0.2",
                         "dae_port": 3799,
@@ -383,6 +383,9 @@ config wifi-iface 'wifi_wlan0'
 
     def test_parse_wpa3_enterprise(self):
         o = OpenWrt(native=self._wpa3_enterprise_ap_uci)
+        from pprint import pprint
+
+        pprint(dict(o.config))
         self.assertEqual(o.config, self._wpa3_enterprise_ap_netjson)
 
     _wpa2_enterprise_ap_netjson = {
@@ -401,7 +404,7 @@ config wifi-iface 'wifi_wlan0'
                         "server": "192.168.0.1",
                         "port": 1812,
                         "acct_server": "192.168.0.2",
-                        "acct_port": 1813,
+                        "acct_server_port": 1813,
                         "nasid": "2",
                         "wpa_group_rekey": "350",
                     },


### PR DESCRIPTION
- Generate "auth_sever", "auth_port" and "auth_secret" options from "server", "port" and "key" properties
- Set "acct_secret" to the value of "key" if it is not configured in NetJSON
- Add new options: "acct_inverval", "dae_client", "dae_port", "dae_secret"

Closes #291