### PR TITLE
[change] Wireguard: do not remove default options

### DIFF
--- a/netjsonconfig/backends/wireguard/converters.py
+++ b/netjsonconfig/backends/wireguard/converters.py
@@ -43,11 +43,6 @@ class Wireguard(BaseConverter):
                 config[self._forward_property_map[option]] = config.pop(option)
             else:
                 config.pop(option, None)
-        # Remove default options
-        if config.get('Table') == 'auto':
-            config.pop('Table')
-        if config.get('MTU') == 1280:
-            config.pop('MTU')
         config['peers'] = self.__intermediate_peers(config.get('peers', []))
         return self.sorted_dict(config)
 

--- a/tests/wireguard/test_backend.py
+++ b/tests/wireguard/test_backend.py
@@ -60,6 +60,7 @@ PostUp = ip rule add ipproto tcp dport 22 table 1234
 PreDown = ip rule delete ipproto tcp dport 22 table 1234
 PrivateKey = QFdbnuYr7rrF4eONCAs7FhZwP7BXX/jD/jq2LXCpaXI=
 SaveConfig = true
+Table = auto
 
 # wireguard config: test2
 
@@ -67,6 +68,7 @@ SaveConfig = true
 Address = 10.0.1.1/24
 DNS = 10.0.1.1,10.0.0.1
 ListenPort = 40843
+MTU = 1280
 PrivateKey = AFdbnuYr7rrF4eONCAs7FhZwP7BXX/jD/jq2LXCpaXI=
 Table = 1234
 """


### PR DESCRIPTION
In one case I experienced the MTU not being set to the expected default of 1280. Including the default values in the configuration can't hurt.