### PR TITLE
[fix] Fixed automatic attachment of wireless interface to network interface #314

### DIFF
--- a/docs/source/backends/openwrt.rst
+++ b/docs/source/backends/openwrt.rst
@@ -1326,15 +1326,15 @@ UCI Output:
     package wireless
 
     config wifi-iface 'wifi_wlan0'
-                option bssid '00:26:b9:20:5f:09'
-                option device 'radio0'
-                option eap_type 'tls'
-                option encryption 'wpa2'
-                option identity 'test-identity'
-                option ifname 'wlan0'
-                option mode 'sta'
-                option password 'test-password'
-                option ssid 'enterprise-client'
+            option bssid '00:26:b9:20:5f:09'
+            option device 'radio0'
+            option eap_type 'tls'
+            option encryption 'wpa2'
+            option identity 'test-identity'
+            option ifname 'wlan0'
+            option mode 'sta'
+            option password 'test-password'
+            option ssid 'enterprise-client'
 
 WPA3 Personal (Simultaneous Authentication of Equals)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1373,13 +1373,13 @@ UCI output:
     package wireless
 
     config wifi-iface 'wifi_wlan0'
-                option device 'radio0'
-                option encryption 'sae+ccmp'
-                option ieee80211w '2'
-                option ifname 'wlan0'
-                option key 'passphrase012345'
-                option mode 'ap'
-                option ssid 'wpa3-personal'
+            option device 'radio0'
+            option encryption 'sae+ccmp'
+            option ieee80211w '2'
+            option ifname 'wlan0'
+            option key 'passphrase012345'
+            option mode 'ap'
+            option ssid 'wpa3-personal'
 
 WPA3 Enterprise (802.1x) AP
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1423,22 +1423,22 @@ UCI Output:
     package wireless
 
     config wifi-iface 'wifi_wlan0'
-                option acct_port '1813'
-                option acct_secret 'radius_secret'
-                option acct_server '192.168.0.2'
-                option auth_port '1812'
-                option auth_secret 'radius_secret'
-                option auth_server '192.168.0.1'
-                option device 'radio0'
-                option encryption 'wpa3+ccmp'
-                option ieee80211w '2'
-                option ifname 'wlan0'
-                option key 'radius_secret'
-                option mode 'ap'
-                option nasid 'hostname'
-                option port '1812'
-                option server '192.168.0.1'
-                option ssid 'eduroam'
+            option acct_port '1813'
+            option acct_secret 'radius_secret'
+            option acct_server '192.168.0.2'
+            option auth_port '1812'
+            option auth_secret 'radius_secret'
+            option auth_server '192.168.0.1'
+            option device 'radio0'
+            option encryption 'wpa3+ccmp'
+            option ieee80211w '2'
+            option ifname 'wlan0'
+            option key 'radius_secret'
+            option mode 'ap'
+            option nasid 'hostname'
+            option port '1812'
+            option server '192.168.0.1'
+            option ssid 'eduroam'
 
 WPA3 Enterprise (802.1x) client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1523,16 +1523,16 @@ UCI Output:
     package wireless
 
     config wifi-iface 'wifi_wlan0'
-                option auth 'MSCHAPV2'
-                option bssid '00:26:b9:20:5f:09'
-                option device 'radio0'
-                option eap_type 'ttls'
-                option encryption 'wpa2'
-                option identity 'test-identity'
-                option ifname 'wlan0'
-                option mode 'sta'
-                option password 'test-password'
-                option ssid 'enterprise-client'
+            option auth 'MSCHAPV2'
+            option bssid '00:26:b9:20:5f:09'
+            option device 'radio0'
+            option eap_type 'ttls'
+            option encryption 'wpa2'
+            option identity 'test-identity'
+            option ifname 'wlan0'
+            option mode 'sta'
+            option password 'test-password'
+            option ssid 'enterprise-client'
 
 *WPA2 Enterprise (802.1x)* client with EAP-PEAP example:
 

--- a/docs/source/backends/openwrt.rst
+++ b/docs/source/backends/openwrt.rst
@@ -407,7 +407,7 @@ Will be rendered as follows:
     package network
 
     config interface 'lo'
-            option ifname 'lo'
+            option device 'lo'
             option ipaddr '127.0.0.1'
             option netmask '255.0.0.0'
             option proto 'static'
@@ -449,7 +449,7 @@ Will be rendered as follows:
     package network
 
     config interface 'eth0'
-        option ifname 'eth0'
+        option device 'eth0'
         option ip6addr 'fdb4:5f35:e8fd::1/48'
         option ipaddr '10.27.251.1'
         option netmask '255.255.255.0'
@@ -506,18 +506,18 @@ Will return the following UCI output:
     config interface 'eth0'
             option dns '10.11.12.13 8.8.8.8'
             option dns_search 'openwisp.org netjson.org'
-            option ifname 'eth0'
+            option device 'eth0'
             option ipaddr '192.168.1.1'
             option netmask '255.255.255.0'
             option proto 'static'
 
     config interface 'eth1'
             option dns_search 'openwisp.org netjson.org'
-            option ifname 'eth1'
+            option device 'eth1'
             option proto 'dhcp'
 
     config interface 'eth1_31'
-            option ifname 'eth1.31'
+            option device 'eth1.31'
             option proto 'none'
 
 DHCP ipv6 ethernet interface
@@ -545,14 +545,14 @@ Will be rendered as follows:
     package network
 
     config interface 'lan'
-            option ifname 'eth0'
+            option device 'eth0'
             option proto 'dchpv6'
 
 Using different protocols
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-OpenWRT and LEDE support many protocols (pppoe, pppoa, pptp, l2tp, ecc)
-and the list of supported protocols evolves over time.
+OpenWRT supports many protocols (pppoe, pppoa, pptp, l2tp, ecc) and the
+list of supported protocols evolves over time.
 
 OpenWISP and netjsonconfig try to stay out of your way by leaving you
 maximum flexibility to use any protocol and any configuration option you
@@ -680,11 +680,11 @@ Will be rendered as follows:
     package network
 
     config interface 'lan'
-            option ifname 'eth0.1'
+            option device 'eth0.1'
             option proto 'none'
 
     config interface 'wan'
-            option ifname 'eth0.2'
+            option device 'eth0.2'
             option proto 'none'
 
     config device 'device_br_lan'
@@ -697,13 +697,9 @@ Will be rendered as follows:
 
     config interface 'br_lan'
             option device 'br-lan'
-            option ifname 'eth0.1 eth0.2'
-            option igmp_snooping '1'
             option ipaddr '172.17.0.2'
             option netmask '255.255.255.0'
             option proto 'static'
-            option stp '1'
-            option type 'bridge'
 
 Wireless settings
 -----------------
@@ -828,12 +824,6 @@ UCI output:
 
 ::
 
-    package network
-
-    config interface 'wlan0'
-            option ifname 'wlan0'
-            option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
@@ -841,7 +831,6 @@ UCI output:
             option ifname 'wlan0'
             option isolate '1'
             option mode 'ap'
-            option network 'wlan0'
             option ssid 'myWiFi'
             option wmm '1'
 
@@ -892,23 +881,18 @@ Will be rendered as follows:
     package network
 
     config interface 'eth0'
-            option ifname 'eth0'
-            option proto 'none'
-
-    config interface 'wlan0'
-            option ifname 'wlan0'
+            option device 'eth0'
             option proto 'none'
 
     config device 'device_lan'
-            option name 'lan'
+            option name 'br-lan'
             list ports 'eth0'
             list ports 'wlan0'
             option type 'bridge'
 
     config interface 'lan'
-            option ifname 'eth0 wlan0'
+            option device 'br-lan'
             option proto 'dhcp'
-            option type 'bridge'
 
     package wireless
 
@@ -952,12 +936,6 @@ UCI output:
 
 ::
 
-    package network
-
-    config interface 'wlan0'
-            option ifname 'wlan0'
-            option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
@@ -967,7 +945,6 @@ UCI output:
             list maclist 'E8:94:F6:33:8C:1D'
             list maclist '42:6c:8f:95:0f:00'
             option mode 'ap'
-            option network 'wlan0'
             option ssid 'MyWifiAP'
 
 Wireless access point with roaming (802.11r)
@@ -1006,12 +983,6 @@ access point:
 UCI output:
 
 ::
-
-    package network
-
-    config interface 'wlan0'
-        option ifname 'wlan0'
-        option proto 'none'
 
     package wireless
 
@@ -1077,25 +1048,20 @@ UCI output:
     package network
 
     config interface 'eth0'
-            option ifname 'eth0'
-            option proto 'none'
-
-    config interface 'mesh0'
-            option ifname 'mesh0'
+            option device 'eth0'
             option proto 'none'
 
     config device 'device_lan'
-            option name 'lan'
+            option name 'br-lan'
             list ports 'eth0'
             list ports 'mesh0'
             option type 'bridge'
 
     config interface 'lan'
-            option ifname 'eth0 mesh0'
+            option device 'br-lan'
             option ipaddr '192.168.0.1'
             option netmask '255.255.255.0'
             option proto 'static'
-            option type 'bridge'
 
     package wireless
 
@@ -1134,12 +1100,6 @@ Will result in:
 
 ::
 
-    package network
-
-    config interface 'wlan0'
-            option ifname 'wlan0'
-            option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
@@ -1147,7 +1107,6 @@ Will result in:
             option device 'radio0'
             option ifname 'wlan0'
             option mode 'adhoc'
-            option network 'wlan0'
             option ssid 'freifunk'
 
 WDS repeater example
@@ -1204,14 +1163,6 @@ Will result in:
 
     package network
 
-    config interface 'wlan0'
-            option ifname 'wlan0'
-            option proto 'none'
-
-    config interface 'wlan1'
-            option ifname 'wlan1'
-            option proto 'none'
-
     config device 'device_wds_bridge'
             option name 'br-wds'
             list ports 'wlan0'
@@ -1219,9 +1170,8 @@ Will result in:
             option type 'bridge'
 
     config interface 'wds_bridge'
-            option ifname 'wlan0 wlan1'
+            option device 'br-wds'
             option proto 'dhcp'
-            option type 'bridge'
 
     package wireless
 
@@ -1274,12 +1224,6 @@ UCI output:
 
 ::
 
-    package network
-
-    config interface 'wlan0'
-            option ifname 'wlan0'
-            option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
@@ -1288,7 +1232,6 @@ UCI output:
             option ifname 'wlan0'
             option key 'passphrase012345'
             option mode 'ap'
-            option network 'wlan0'
             option ssid 'wpa2-personal'
 
 WPA2 Enterprise (802.1x) ap
@@ -1328,24 +1271,21 @@ UCI Output:
 
 ::
 
-    package network
-
-    config interface 'wlan0'
-            option ifname 'wlan0'
-            option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
             option acct_port '1813'
+            option acct_secret 'radius_secret'
             option acct_server '192.168.0.2'
+            option auth_port '1812'
+            option auth_secret 'radius_secret'
+            option auth_server '192.168.0.1'
             option device 'radio0'
             option encryption 'wpa2'
             option ifname 'wlan0'
             option key 'radius_secret'
             option mode 'ap'
             option nasid 'hostname'
-            option network 'wlan0'
             option port '1812'
             option server '192.168.0.1'
             option ssid 'eduroam'
@@ -1383,25 +1323,18 @@ UCI Output:
 
 ::
 
-    package network
-
-    config interface 'wlan0'
-            option ifname 'wlan0'
-            option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
-            option bssid '00:26:b9:20:5f:09'
-            option device 'radio0'
-            option eap_type 'tls'
-            option encryption 'wpa2'
-            option identity 'test-identity'
-            option ifname 'wlan0'
-            option mode 'sta'
-            option network 'wlan0'
-            option password 'test-password'
-            option ssid 'enterprise-client'
+                option bssid '00:26:b9:20:5f:09'
+                option device 'radio0'
+                option eap_type 'tls'
+                option encryption 'wpa2'
+                option identity 'test-identity'
+                option ifname 'wlan0'
+                option mode 'sta'
+                option password 'test-password'
+                option ssid 'enterprise-client'
 
 WPA3 Personal (Simultaneous Authentication of Equals)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1437,25 +1370,18 @@ UCI output:
 
 ::
 
-    package network
-
-    config interface `'wlan0'
-            option ifname 'wlan0'
-            option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
-            option device 'radio0'
-            option encryption 'sae+ccmp'
-            option ieee80211w '2'
-            option ifname 'wlan0'
-            option key 'passphrase012345'
-            option mode 'ap'
-            option network 'wlan0'
-            option ssid 'wpa3-personal'
+                option device 'radio0'
+                option encryption 'sae+ccmp'
+                option ieee80211w '2'
+                option ifname 'wlan0'
+                option key 'passphrase012345'
+                option mode 'ap'
+                option ssid 'wpa3-personal'
 
-WPA3 Enterprise (802.1x) ap
+WPA3 Enterprise (802.1x) AP
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example shows a typical wireless access point using *WPA3
@@ -1494,28 +1420,25 @@ UCI Output:
 
 ::
 
-    package network
-
-    config interface 'wlan0'
-            option ifname 'wlan0'
-            option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
-            option acct_port '1813'
-            option acct_server '192.168.0.2'
-            option device 'radio0'
-            option encryption 'wpa3+ccmp'
-            option ieee80211w '2'
-            option ifname 'wlan0'
-            option key 'radius_secret'
-            option mode 'ap'
-            option nasid 'hostname'
-            option network 'wlan0'
-            option port '1812'
-            option server '192.168.0.1'
-            option ssid 'eduroam'
+                option acct_port '1813'
+                option acct_secret 'radius_secret'
+                option acct_server '192.168.0.2'
+                option auth_port '1812'
+                option auth_secret 'radius_secret'
+                option auth_server '192.168.0.1'
+                option device 'radio0'
+                option encryption 'wpa3+ccmp'
+                option ieee80211w '2'
+                option ifname 'wlan0'
+                option key 'radius_secret'
+                option mode 'ap'
+                option nasid 'hostname'
+                option port '1812'
+                option server '192.168.0.1'
+                option ssid 'eduroam'
 
 WPA3 Enterprise (802.1x) client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1552,12 +1475,6 @@ UCI Output:
 
 ::
 
-    package network
-
-    config interface 'wlan0'
-            option ifname 'wlan0'
-            option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
@@ -1569,7 +1486,6 @@ UCI Output:
             option ieee80211w '2'
             option ifname 'wlan0'
             option mode 'sta'
-            option network 'wlan0'
             option password 'test-password'
             option ssid 'enterprise-client'
 
@@ -1604,26 +1520,19 @@ UCI Output:
 
 ::
 
-    package network
-
-    config interface 'wlan0'
-        option ifname 'wlan0'
-        option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
-        option auth 'MSCHAPV2'
-        option bssid '00:26:b9:20:5f:09'
-        option device 'radio0'
-        option eap_type 'ttls'
-        option encryption 'wpa2'
-        option identity 'test-identity'
-        option ifname 'wlan0'
-        option mode 'sta'
-        option network 'wlan0'
-        option password 'test-password'
-        option ssid 'enterprise-client'
+                option auth 'MSCHAPV2'
+                option bssid '00:26:b9:20:5f:09'
+                option device 'radio0'
+                option eap_type 'ttls'
+                option encryption 'wpa2'
+                option identity 'test-identity'
+                option ifname 'wlan0'
+                option mode 'sta'
+                option password 'test-password'
+                option ssid 'enterprise-client'
 
 *WPA2 Enterprise (802.1x)* client with EAP-PEAP example:
 
@@ -1656,26 +1565,19 @@ UCI Output:
 
 ::
 
-    package network
-
-    config interface 'wlan0'
-        option ifname 'wlan0'
-        option proto 'none'
-
     package wireless
 
     config wifi-iface 'wifi_wlan0'
-        option auth 'EAP-MSCHAPV2'
-        option bssid '00:26:b9:20:5f:09'
-        option device 'radio0'
-        option eap_type 'peap'
-        option encryption 'wpa2'
-        option identity 'test-identity'
-        option ifname 'wlan0'
-        option mode 'sta'
-        option network 'wlan0'
-        option password 'test-password'
-        option ssid 'enterprise-client'
+            option auth 'EAP-MSCHAPV2'
+            option bssid '00:26:b9:20:5f:09'
+            option device 'radio0'
+            option eap_type 'peap'
+            option encryption 'wpa2'
+            option identity 'test-identity'
+            option ifname 'wlan0'
+            option mode 'sta'
+            option password 'test-password'
+            option ssid 'enterprise-client'
 
 Dialup settings
 ---------------
@@ -1707,6 +1609,7 @@ The following *configuration dictionary*:
             {
                 "name": "dsl0",
                 "network": "xdsl",
+                "type": "dialup",
                 "proto": "pppoe",
                 "password": "jf93nf82o023$",
                 "username": "dsluser",
@@ -1723,10 +1626,10 @@ Will be rendered as follows:
 
     config interface 'xdsl'
             option ifname 'dsl0'
+            option mtu '1448'
+            option password 'jf93nf82o023$'
             option proto 'pppoe'
             option username 'dsluser'
-            option password 'jf93nf82o023$'
-            option mtu '1448'
 
 Modem Manager settings
 ----------------------
@@ -1867,20 +1770,19 @@ Will be rendered as follows:
     package wireless
 
     config wifi-device 'radio0'
+            option band '2g'
             option channel '11'
             option country 'IT'
             option htmode 'HT20'
-            option band '2g'
             option phy 'phy0'
             option txpower '5'
             option type 'mac80211'
 
     config wifi-device 'radio1'
+            option band '5g'
             option channel '36'
             option country 'IT'
-            option disabled '0'
             option htmode 'HT20'
-            option band '5g'
             option phy 'phy1'
             option txpower '4'
             option type 'mac80211'
@@ -1931,16 +1833,16 @@ UCI output:
     package wireless
 
     config wifi-device 'radio0'
+            option band '2g'
             option channel 'auto'
             option htmode 'HT20'
-            option band '2g'
             option phy 'phy0'
             option type 'mac80211'
 
     config wifi-device 'radio1'
+            option band '5g'
             option channel 'auto'
             option htmode 'VHT80'
-            option band '5g'
             option phy 'phy1'
             option type 'mac80211'
 
@@ -1972,9 +1874,9 @@ UCI output:
     package wireless
 
     config wifi-device 'radio0'
+            option band '5g'
             option channel '36'
             option htmode 'VHT80'
-            option band '5g'
             option phy 'phy0'
             option type 'mac80211'
 
@@ -2006,9 +1908,9 @@ UCI output:
     package wireless
 
     config wifi-device 'radio0'
+            option band '5g'
             option channel '36'
             option htmode 'HE80'
-            option band '5g'
             option phy 'phy0'
             option type 'mac80211'
 

--- a/netjsonconfig/backends/openwrt/converters/interfaces.py
+++ b/netjsonconfig/backends/openwrt/converters/interfaces.py
@@ -493,13 +493,12 @@ class Interfaces(OpenWrtConverter):
                     if option in device_config:
                         interface[option] = device_config.pop(option)
             # if device_config is empty but the interface references it
-            elif 'device' in interface:
+            elif 'device' in interface and 'ifname' not in interface:
                 # .name may have '.' substituted with _,
                 # which will yield unexpected results
                 # for this reason we use the name stored
                 # in the device property before removing it
-                if 'ifname' not in interface:
-                    interface['ifname'] = interface.pop('device')
+                interface['ifname'] = interface.pop('device')
         return interface
 
     def __netjson_device(self, interface):

--- a/netjsonconfig/backends/openwrt/converters/interfaces.py
+++ b/netjsonconfig/backends/openwrt/converters/interfaces.py
@@ -492,10 +492,14 @@ class Interfaces(OpenWrtConverter):
                 ):
                     if option in device_config:
                         interface[option] = device_config.pop(option)
-            # if device_config is empty but the interface references
-            # remove its reference from the interface
+            # if device_config is empty but the interface references it
             elif 'device' in interface:
-                del interface['device']
+                # .name may have '.' substituted with _,
+                # which will yield unexpected results
+                # for this reason we use the name stored
+                # in the device property before removing it
+                if 'ifname' not in interface:
+                    interface['ifname'] = interface.pop('device')
         return interface
 
     def __netjson_device(self, interface):

--- a/netjsonconfig/backends/openwrt/converters/wireless.py
+++ b/netjsonconfig/backends/openwrt/converters/wireless.py
@@ -73,8 +73,13 @@ class Wireless(OpenWrtConverter):
             try:
                 bridges = self._bridged_wifi[interface['name']]
             except KeyError:
-                # don't bridge to anything unless explicitly specified
-                network = []
+                # if interface has any address specified,
+                # we need to attach it in the OpenWrt config
+                if interface.get('addresses', []):
+                    network = [interface['name']]
+                else:
+                    # don't bridge to anything unless explicitly specified
+                    network = []
             else:
                 network = bridges
             wireless['network'] = network
@@ -295,7 +300,8 @@ class Wireless(OpenWrtConverter):
         wps = False
         # move encryption keys
         for key in self._encryption_keys:
-            if key in wifi:
+            value = wifi.get(key, None)
+            if key in wifi and value:
                 settings[key] = wifi.pop(key)
                 if key.startswith('wps_'):
                     wps = True

--- a/tests/openwrt/test_backend.py
+++ b/tests/openwrt/test_backend.py
@@ -157,6 +157,7 @@ class TestBackend(unittest.TestCase, _TabsMixin):
         contents = tar.extractfile(network).read().decode()
         expected = self._tabs(
             """config interface 'wlan0'
+    option device 'wlan0'
     option ipaddr '192.168.1.1'
     option netmask '255.255.255.0'
     option proto 'static'
@@ -181,6 +182,7 @@ config wifi-iface 'wifi_wlan0'
     option hidden '1'
     option ifname 'wlan0'
     option mode 'ap'
+    option network 'wlan0'
     option ssid 'MyWifiAP'
 """
         )

--- a/tests/openwrt/test_interfaces_dsa.py
+++ b/tests/openwrt/test_interfaces_dsa.py
@@ -31,9 +31,6 @@ class TestInterfaces(unittest.TestCase, _TabsMixin):
         expected = self._tabs(
             """package network
 
-config device 'device_lo'
-    option name 'lo'
-
 config interface 'lo'
     option device 'lo'
     option ipaddr '127.0.0.1'
@@ -335,9 +332,6 @@ config interface 'eth0'
 
     _multi_ip_uci = """package network
 
-config device 'device_eth0_1'
-    option name 'eth0.1'
-
 config interface 'eth0_1'
     option auto '1'
     option device 'eth0.1'
@@ -381,9 +375,6 @@ config interface 'eth0_1'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option ip6addr 'fd87::2/64'
@@ -407,9 +398,6 @@ config interface 'eth0'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option proto 'dhcp'
@@ -418,11 +406,19 @@ config interface 'eth0'
         self.assertEqual(o.render(), expected)
 
     def test_parse_dhcp(self):
-        native = self._tabs(
+        native1 = self._tabs(
             """package network
 
 config device 'device_eth0'
     option name 'eth0'
+
+config interface 'eth0'
+    option device 'eth0'
+    option proto 'dhcp'
+"""
+        )
+        native2 = self._tabs(
+            """package network
 
 config interface 'eth0'
     option device 'eth0'
@@ -438,7 +434,9 @@ config interface 'eth0'
                 }
             ]
         }
-        o = OpenWrt(native=native)
+        o = OpenWrt(native=native1)
+        self.assertEqual(o.config, expected)
+        o = OpenWrt(native=native2)
         self.assertEqual(o.config, expected)
 
     def test_parse_dhcpv6(self):
@@ -482,9 +480,6 @@ config interface 'eth0'
         )
         expected = self._tabs(
             """package network
-
-config device 'device_eth0'
-    option name 'eth0'
 
 config interface 'eth0'
     option device 'eth0'
@@ -559,9 +554,6 @@ config interface 'eth0_2'
         )
         expected = self._tabs(
             """package network
-
-config device 'device_eth0'
-    option name 'eth0'
 
 config interface 'eth0'
     option device 'eth0'
@@ -691,9 +683,6 @@ config interface 'custom_if0'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option enabled '0'
@@ -791,15 +780,9 @@ config interface 'mobile0'
     }
     _simple_bridge_uci = """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option proto 'none'
-
-config device 'device_eth1'
-    option name 'eth1'
 
 config interface 'eth1'
     option device 'eth1'
@@ -859,15 +842,9 @@ config interface 'lan'
 
     _complex_bridge_uci = """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option proto 'none'
-
-config device 'device_eth1'
-    option name 'eth1'
 
 config interface 'eth1'
     option device 'eth1'
@@ -1013,12 +990,6 @@ config interface 'lan'
 
     _bridge_21_bridge_uci = """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
-config device 'device_eth1'
-    option name 'eth1'
-
 config interface 'eth0'
     option device 'eth0'
     option proto 'none'
@@ -1069,15 +1040,9 @@ config interface 'lan'
     }
     _l2_options_bridge_uci = """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option proto 'none'
-
-config device 'device_eth1'
-    option name 'eth1'
 
 config interface 'eth1'
     option device 'eth1'
@@ -1169,9 +1134,6 @@ config interface 'wan'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option dns '10.11.12.13 8.8.8.8'
@@ -1205,9 +1167,6 @@ config interface 'eth0'
     def test_parse_dns(self):
         native = self._tabs(
             """package network
-
-config device 'device_eth0'
-    option name 'eth0'
 
 config interface 'eth0'
     option dns '10.11.12.13 8.8.8.8'
@@ -1259,9 +1218,6 @@ config interface 'eth0'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option dns_search 'netjson.org openwisp.org'
@@ -1287,9 +1243,6 @@ config interface 'eth0'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option dns_search 'netjson.org openwisp.org'
@@ -1309,9 +1262,6 @@ config interface 'eth0'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option proto 'none'
@@ -1323,9 +1273,6 @@ config interface 'eth0'
         o = OpenWrt({"interfaces": [{"name": "eth0", "type": "ethernet"}]})
         expected = self._tabs(
             """package network
-
-config device 'device_eth0'
-    option name 'eth0'
 
 config interface 'eth0'
     option device 'eth0'
@@ -1405,9 +1352,6 @@ config interface 'eth0'
         expected = self._tabs(
             """package network
 
-config device 'device_lan'
-    option name 'eth0'
-
 config interface 'lan'
     option device 'eth0'
     option ipaddr '192.168.1.1'
@@ -1446,9 +1390,6 @@ config interface 'lan'
         expected = self._tabs(
             """package network
 
-config device 'device_lan_1'
-    option name 'eth0.1'
-
 config interface 'lan_1'
     option device 'eth0.1'
     option proto 'none'
@@ -1462,9 +1403,6 @@ config interface 'lan_1'
         )
         expected = self._tabs(
             """package network
-
-config device 'device_lan_0'
-    option name 'eth-0'
 
 config interface 'lan_0'
     option device 'eth-0'
@@ -1545,9 +1483,6 @@ config interface 'lan'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     list ip6class 'wan6'
@@ -1573,9 +1508,6 @@ config interface 'eth0'
         )
         expected = self._tabs(
             """package network
-
-config device 'device_eth0'
-    option name 'eth0'
 
 config interface 'eth0'
     option device 'eth0'
@@ -1620,9 +1552,6 @@ config interface 'eth0'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     list dns '8.8.8.8'
@@ -1647,9 +1576,6 @@ config interface 'eth0'
         )
         expected = self._tabs(
             """package network
-
-config device 'device_eth0'
-    option name 'eth0'
 
 config interface 'eth0'
     option device 'eth0'
@@ -1787,9 +1713,6 @@ config interface 'br_lan'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option auto '0'
     option device 'eth0'
@@ -1801,9 +1724,6 @@ config interface 'eth0'
     def test_parse_autostart_false(self):
         native = self._tabs(
             """package network
-
-config device 'device_eth0'
-    option name 'eth0'
 
 config interface 'eth0'
     option auto '0'
@@ -1877,9 +1797,6 @@ config interface 'eth0'
         expected = self._tabs(
             """package network
 
-config device 'device_eth0'
-    option name 'eth0'
-
 config interface 'eth0'
     option device 'eth0'
     option proto 'none'
@@ -1897,9 +1814,6 @@ config interface 'eth0'
         )
         expected = self._tabs(
             """package network
-
-config device 'device_eth0'
-    option name 'eth0'
 
 config interface 'eth0'
     option device 'eth0'

--- a/tests/openwrt/test_wireless.py
+++ b/tests/openwrt/test_wireless.py
@@ -184,9 +184,6 @@ config wifi-iface 'wifi_wlan1'
     }
     _wifi_bridge_uci = """package network
 
-config device 'device_eth0_1'
-    option name 'eth0.1'
-
 config interface 'eth0_1'
     option device 'eth0.1'
     option proto 'none'

--- a/tests/openwrt/test_wireless.py
+++ b/tests/openwrt/test_wireless.py
@@ -38,6 +38,7 @@ class TestWireless(unittest.TestCase, _TabsMixin):
     _wifi_uci = """package network
 
 config interface 'wlan0'
+    option device 'wlan0'
     option ipaddr '192.168.1.1'
     option netmask '255.255.255.0'
     option proto 'static'
@@ -52,6 +53,7 @@ config wifi-iface 'wifi_wlan0'
     option ifname 'wlan0'
     option isolate '1'
     option mode 'ap'
+    option network 'wlan0'
     option rts '1300'
     option ssid 'MyWifiAP'
 """
@@ -123,9 +125,11 @@ config wifi-iface 'wifi_wlan0'
     _multiple_wifi_uci = """package network
 
 config interface 'wlan0'
+    option device 'wlan0'
     option proto 'dhcp'
 
 config interface 'wlan1'
+    option device 'wlan1'
     option proto 'dhcp'
 
 package wireless
@@ -134,6 +138,7 @@ config wifi-iface 'wifi_wlan0'
     option device 'radio0'
     option ifname 'wlan0'
     option mode 'ap'
+    option network 'wlan0'
     option ssid 'ap-ssid'
 
 config wifi-iface 'wifi_wlan1'
@@ -141,6 +146,7 @@ config wifi-iface 'wifi_wlan1'
     option device 'radio1'
     option ifname 'wlan1'
     option mode 'adhoc'
+    option network 'wlan1'
     option ssid 'adhoc-ssid'
 """
 
@@ -234,6 +240,7 @@ config wifi-iface 'wifi_wlan0'
     _wifi_networks_uci = """package network
 
 config interface 'wsta0'
+    option device 'wsta0'
     option proto 'dhcp'
 
 package wireless
@@ -242,6 +249,7 @@ config wifi-iface 'wifi_wsta0'
     option device 'radio0'
     option ifname 'wsta0'
     option mode 'sta'
+    option network 'wsta0'
     option ssid 'open'
     option wds '0'
 """
@@ -1167,3 +1175,101 @@ config wifi-iface 'wifi_wlan1'
     def test_parse_wireless_only(self):
         o = OpenWrt(native=self._wireless_only_uci)
         self.assertDictEqual(o.config, self._wireless_only_netjson)
+
+    _sta_in_dhcp_client_json = {
+        "interfaces": [
+            {
+                "name": "wwan",
+                "type": "wireless",
+                "mac": "00:11:22:33:44:55",
+                "mtu": 1500,
+                "addresses": [{"proto": "dhcp", "family": "ipv4"}],
+                "wireless": {
+                    "mode": "station",
+                    "radio": "radio1",
+                    "ssid": "SSID",
+                    "wds": False,
+                    "encryption": {
+                        "cipher": "auto",
+                        "ieee80211w": "1",
+                        "protocol": "wpa2_enterprise",
+                        "eap_type": "ttls",
+                        "auth": "PAP",
+                        "identity": "username",
+                        "password": "password123",
+                    },
+                },
+            }
+        ]
+    }
+    _sta_in_dhcp_client_uci = """package network
+
+config device 'device_wwan'
+    option mtu '1500'
+    option name 'wwan'
+
+config interface 'wwan'
+    option device 'wwan'
+    option proto 'dhcp'
+
+package wireless
+
+config wifi-iface 'wifi_wwan'
+    option auth 'PAP'
+    option device 'radio1'
+    option eap_type 'ttls'
+    option encryption 'wpa2'
+    option identity 'username'
+    option ieee80211w '1'
+    option ifname 'wwan'
+    option macaddr '00:11:22:33:44:55'
+    option mode 'sta'
+    option network 'wwan'
+    option password 'password123'
+    option ssid 'SSID'
+    option wds '0'
+"""
+
+    _sta_in_dhcp_client_no_mtu_json = deepcopy(_sta_in_dhcp_client_json)
+    del _sta_in_dhcp_client_no_mtu_json['interfaces'][0]['mtu']
+    _sta_in_dhcp_client_no_mtu_uci = """package network
+
+config interface 'wwan'
+    option device 'wwan'
+    option proto 'dhcp'
+
+package wireless
+
+config wifi-iface 'wifi_wwan'
+    option auth 'PAP'
+    option device 'radio1'
+    option eap_type 'ttls'
+    option encryption 'wpa2'
+    option identity 'username'
+    option ieee80211w '1'
+    option ifname 'wwan'
+    option macaddr '00:11:22:33:44:55'
+    option mode 'sta'
+    option network 'wwan'
+    option password 'password123'
+    option ssid 'SSID'
+    option wds '0'
+"""
+
+    def test_render_sta_in_dhcp_client(self):
+        o = OpenWrt(self._sta_in_dhcp_client_json)
+        expected = self._tabs(self._sta_in_dhcp_client_uci)
+        self.assertEqual(o.render(), expected)
+
+    def test_parse_sta_in_dhcp_client(self):
+        o = OpenWrt(native=self._sta_in_dhcp_client_uci)
+        self.assertDictEqual(o.config, self._sta_in_dhcp_client_json)
+
+    def test_render_sta_in_dhcp_client_no_mtu(self):
+        o = OpenWrt(self._sta_in_dhcp_client_no_mtu_json)
+        expected = self._tabs(self._sta_in_dhcp_client_no_mtu_uci)
+        self.assertEqual(o.render(), expected)
+
+    def test_parse_sta_in_dhcp_client_no_mtu(self):
+        o = OpenWrt(native=self._sta_in_dhcp_client_no_mtu_uci)
+        self.assertDictEqual(o.config, self._sta_in_dhcp_client_no_mtu_json)

--- a/tests/openwrt/test_wireless_legacy.py
+++ b/tests/openwrt/test_wireless_legacy.py
@@ -51,6 +51,7 @@ config wifi-iface 'wifi_wlan0'
     option hidden '1'
     option ifname 'wlan0'
     option mode 'ap'
+    option network 'wlan0'
     option rts '1300'
     option ssid 'MyWifiAP'
 """
@@ -132,6 +133,7 @@ config wifi-iface 'wifi_wlan0'
     option device 'radio0'
     option ifname 'wlan0'
     option mode 'ap'
+    option network 'wlan0'
     option ssid 'ap-ssid'
 
 config wifi-iface 'wifi_wlan1'
@@ -139,6 +141,7 @@ config wifi-iface 'wifi_wlan1'
     option device 'radio1'
     option ifname 'wlan1'
     option mode 'adhoc'
+    option network 'wlan1'
     option ssid 'adhoc-ssid'
 """
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Fixes #314.

## Description of Changes

If the wireless interface has any address defined, attach it automatically to the related network interface.
