### PR TITLE
[fix] Fixed ZeroTier schema for allow_managed field

### DIFF
--- a/netjsonconfig/backends/openwrt/schema.py
+++ b/netjsonconfig/backends/openwrt/schema.py
@@ -1258,7 +1258,7 @@ schema = merge_config(
                                         "format": "checkbox",
                                         "description": (
                                             "Allow ZeroTier to set IP Addresses"
-                                            " and Routes (local/private ranges only)",
+                                            " and Routes (local/private ranges only)"
                                         ),
                                     },
                                     "allow_global": {

--- a/netjsonconfig/backends/zerotier/schema.py
+++ b/netjsonconfig/backends/zerotier/schema.py
@@ -78,7 +78,7 @@ base_zerotier_schema = {
                             "default": True,
                             "format": "checkbox",
                             "description": (
-                                "Allow ZeroTier to set IP Addresses and Routes (local/private ranges only)",
+                                "Allow ZeroTier to set IP Addresses and Routes (local/private ranges only)"
                             ),
                         },
                         "allow_global": {


### PR DESCRIPTION
The description for `allow_managed` setting was interpreted as an array instead of a string. 