### PR TITLE
[fix] Fixed development status in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     classifiers=[
-        'Development Status :: 5 - Production/Stable ',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',


### PR DESCRIPTION
## Checklist

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes

Without this fix, the package will not upload to PyPI. 

`twine upload dist/*` gives the following error 

```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/                                                        
         'Development Status :: 5 - Production/Stable ' is not a valid classifier. See                                          
         https://packaging.python.org/specifications/core-metadata for more information. 
```

Moreover, the PyPI CI task was not triggered for 1.1.1 release. 
