### PR TITLE
[bug] WireGuard backend is missing parsers fixes #276

### DIFF
--- a/netjsonconfig/backends/wireguard/parser.py
+++ b/netjsonconfig/backends/wireguard/parser.py
@@ -1,21 +1,64 @@
 import re
-
+import tarfile
+import io
 from ..base.parser import BaseParser
 
-vpn_pattern = re.compile('^# wireguard config:\s', flags=re.MULTILINE)
-config_pattern = re.compile('^([^\s]*) ?(.*)$')
+vpn_pattern = re.compile(r'^\[Interface\]', flags=re.MULTILINE)
+config_pattern = re.compile(r'^([^\s=]+)\s*=\s*(.*)$', flags=re.MULTILINE)
 config_suffix = '.conf'
 
 
 class WireguardParser(BaseParser):
     def parse_text(self, config):
-        raise NotImplementedError()
+        """
+        Parses a WireGuard configuration text into a structured dictionary.
+        """
+        return self._get_config(config)
 
     def parse_tar(self, tar):
-        raise NotImplementedError()
+        """
+        Parses a tar archive containing WireGuard configuration files.
+        """
+        parsed_configs = {}
+        with tarfile.open(fileobj=io.BytesIO(tar), mode='r:*') as archive:
+            for member in archive.getmembers():
+                if member.isfile() and member.name.endswith(config_suffix):
+                    file = archive.extractfile(member)
+                    if file:
+                        content = file.read().decode()
+                        parsed_configs[member.name] = self._get_config(content)
+        return parsed_configs
 
     def _get_vpns(self, text):
-        raise NotImplementedError()
+        """
+        Extracts VPN sections from WireGuard config text.
+        """
+        vpn_sections = []
+        sections = vpn_pattern.split(text)
+        for section in sections[1:]:  # Ignore first split as it's before [Interface]
+            vpn_sections.append(self._get_config(section.strip()))
+        return vpn_sections
 
     def _get_config(self, contents):
-        raise NotImplementedError()
+        """
+        Parses WireGuard config content into a structured dictionary.
+        """
+        config_data = {}
+        current_section = None
+
+        for line in contents.splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue  # Skip empty lines and comments
+
+            if line.startswith('[') and line.endswith(']'):
+                current_section = line[1:-1].lower()
+                config_data[current_section] = {}
+            else:
+                match = config_pattern.match(line)
+                if match and current_section:
+                    key, value = match.groups()
+                    config_data[current_section][key] = value.strip()
+
+        return config_data
+

--- a/netjsonconfig/backends/wireguard/wireguard.py
+++ b/netjsonconfig/backends/wireguard/wireguard.py
@@ -1,6 +1,6 @@
 from ..base.backend import BaseVpnBackend
 from . import converters
-from .parser import config_suffix, vpn_pattern
+from .parser import WireguardParser, config_suffix, vpn_pattern
 from .renderer import WireguardRenderer
 from .schema import schema
 
@@ -9,6 +9,7 @@ class Wireguard(BaseVpnBackend):
     schema = schema
     converters = [converters.Wireguard]
     renderer = WireguardRenderer
+    parser = WireguardParser  # Assign the parser here
     # BaseVpnBackend attributes
     vpn_pattern = vpn_pattern
     config_suffix = config_suffix


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [] I have updated the documentation.

## Reference to Existing Issue

Closes #276.

Please [open a new issue](https://github.com/openwisp/netjsonconfig/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes
This PR implements the missing WireGuard parsers in WireguardParser inside netjsonconfig/netjsonconfig/backends/wireguard/parser.py.

## Changes made:
✅ Implemented parse_text() to parse WireGuard config files into structured dictionaries.
✅ Implemented parse_tar() to handle .tar.gz archives containing multiple WireGuard configurations.
✅ Added helper methods _get_vpns() and _get_config() to extract VPN details.
✅ Updated wireguard.py to integrate the parser.

## Example Config Parsed:
```
[Interface]
Address = 10.0.0.1/24
PrivateKey = abcdefghijklmnopqrstuvwxyz
ListenPort = 51820
DNS = 8.8.8.8

[Peer]
PublicKey = mnopqrstuvwxyzabcdefghij
AllowedIPs = 10.0.0.2/32
Endpoint = 192.168.1.1:51820
```

## Screenshot

Please include any relevant screenshots.
