### PR TITLE
[fix] Update ZeroTier default name from 'ow_zt' to 'global'

### DIFF
--- a/docs/source/backends/zerotier.rst
+++ b/docs/source/backends/zerotier.rst
@@ -300,7 +300,7 @@ Required properties:
 ==================== ======= ========================== =========================
 key name             type    default                    description
 ==================== ======= ========================== =========================
-``name``             string  ``ow_zt``                  name of the zerotier
+``name``             string  ``global``                 name of the zerotier
                                                         network
 ``networks``         list    ``[{}]``                   list of dictionaries
                                                         containing strings with
@@ -363,7 +363,7 @@ Example (with custom zerotier interface name):
     from netjsonconfig import OpenWrt
 
     client_config = OpenWrt.zerotier_auto_client(
-        name="ow_zt",
+        name="global",
         networks=[{"id": "9536600adf654321", "ifname": "owzt654321"}],
     )
     print(OpenWrt(client_config).render())
@@ -374,12 +374,15 @@ Will be rendered as:
 
     package zerotier
 
-    config zerotier 'ow_zt'
+    config zerotier 'global'
         option config_path '/etc/openwisp/zerotier'
         option copy_config_path '1'
         option enabled '1'
         list join '9536600adf654321'
         option secret '{{secret}}'
+
+    config network 'owzt654321'
+        option id '9536600adf654321'
 
     # ---------- files ---------- #
 
@@ -446,7 +449,7 @@ Now add ``local_conf_path`` option to ``/etc/config/zerotier``:
 
     package zerotier
 
-    config zerotier 'ow_zt'
+    config zerotier 'global'
         option enabled '1'
         list join '9536600adf654322'
         option secret '{{secret}}'

--- a/netjsonconfig/backends/zerotier/zerotier.py
+++ b/netjsonconfig/backends/zerotier/zerotier.py
@@ -17,7 +17,7 @@ class ZeroTier(BaseVpnBackend):
     @classmethod
     def auto_client(
         cls,
-        name='ow_zt',
+        name='global',
         networks=None,
         identity_secret='{{secret}}',
         config_path='/etc/openwisp/zerotier',

--- a/tests/openwrt/test_backend.py
+++ b/tests/openwrt/test_backend.py
@@ -548,7 +548,7 @@ config wifi-iface 'wifi_wlan0'
             expected = {
                 'zerotier': [
                     {
-                        'name': 'ow_zt',
+                        'name': 'global',
                         'networks': [],
                         'secret': '{{secret}}',
                         'config_path': '/etc/openwisp/zerotier',
@@ -561,7 +561,7 @@ config wifi-iface 'wifi_wlan0'
             expected = {
                 'zerotier': [
                     {
-                        'name': 'ow_zt',
+                        'name': 'global',
                         'networks': [
                             {'id': '9536600adf654321', 'ifname': 'owzt654321'}
                         ],

--- a/tests/openwrt/test_zerotier.py
+++ b/tests/openwrt/test_zerotier.py
@@ -12,7 +12,7 @@ class TestZeroTier(unittest.TestCase, _TabsMixin):
         "zerotier": [
             {
                 "local_conf_path": "/etc/openwisp/zerotier/zerotier.conf",
-                "name": "ow_zt",
+                "name": "global",
                 "networks": [
                     {
                         "id": "9536600adf654321",
@@ -36,7 +36,7 @@ class TestZeroTier(unittest.TestCase, _TabsMixin):
     }
     _multiple_networks_uci = """package zerotier
 
-config zerotier 'ow_zt'
+config zerotier 'global'
     option config_path '/etc/openwisp/zerotier'
     option copy_config_path '1'
     option enabled '1'
@@ -77,11 +77,11 @@ config network 'owzt654322'
     _TEST_DIFF_NAME_MULTIPLE_CONFIG = {
         "zerotier": [
             {
-                "name": "ow_zt1",
+                "name": "global1",
                 "networks": [{"id": "9536600adf654321", "ifname": "owzt654321"}],
             },
             {
-                "name": "ow_zt2",
+                "name": "global2",
                 "networks": [{"id": "9536600adf654322", "ifname": "owzt654322"}],
             },
         ]
@@ -96,7 +96,7 @@ config network 'owzt654322'
         native = self._tabs(
             """package zerotier
 
-config zerotier 'ow_zt'
+config zerotier 'global'
     option enabled '0'
     option local_conf '/etc/openwisp/zerotier/zerotier.conf'
     list join '9536600adf654321'
@@ -111,7 +111,7 @@ config zerotier 'ow_zt'
                         {"id": "9536600adf654321", "ifname": "owzt654321"},
                         {"id": "9536600adf654322", "ifname": "owzt654322"},
                     ],
-                    "name": "ow_zt",
+                    "name": "global",
                     "disabled": True,
                 },
             ]
@@ -123,7 +123,7 @@ config zerotier 'ow_zt'
         native = self._tabs(
             """package zerotier
 
-config zerotier 'ow_zt'
+config zerotier 'global'
     option enabled '0'
     option local_conf_path '/etc/openwisp/zerotier/zerotier.conf'
 
@@ -153,7 +153,7 @@ config network
                             "allow_dns": False,
                         },
                     ],
-                    "name": "ow_zt",
+                    "name": "global",
                     "disabled": True,
                 },
             ]

--- a/tests/zerotier/test_backend.py
+++ b/tests/zerotier/test_backend.py
@@ -393,7 +393,7 @@ class TestBackend(unittest.TestCase):
         test_config = self._TEST_CONFIG["zerotier"][0]
         nw_id = test_config['id']
         expected = {
-            'name': 'ow_zt',
+            'name': 'global',
             'networks': [{'id': '9536600adf654321', 'ifname': 'owzt654321'}],
             'secret': 'test_secret',
             'config_path': '/etc/openwisp/zerotier',
@@ -401,7 +401,7 @@ class TestBackend(unittest.TestCase):
         }
         self.assertEqual(
             ZeroTier.auto_client(
-                name="ow_zt",
+                name="global",
                 networks=[
                     {
                         'id': nw_id,


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Description of Changes

The configuration format has changed on OpenWrt since ZeroTier 1.14.0. Previously, it supported running multiple services of the ZeroTier controller, but now only one service is allowed called "global".

Hence, the default name is changed from "ow_zt" to "global".

