### PR TITLE
[fix:openwrt] Auto-generate logical name for VLAN 802.1X interface #335

### DIFF
--- a/netjsonconfig/backends/openwrt/converters/interfaces.py
+++ b/netjsonconfig/backends/openwrt/converters/interfaces.py
@@ -232,8 +232,8 @@ class Interfaces(OpenWrtConverter):
 
     def _intermediate_8021_vlan(self, interface):
         interface['name'] = '{}.{}'.format(interface['ifname'], interface['vid'])
-        interface['.name'] = interface.get(
-            'network', 'vlan_{}_{}'.format(interface['.name'], interface['vid'])
+        interface['.name'] = interface.get('network') or 'vlan_{}_{}'.format(
+            interface['.name'], interface['vid']
         )
         return interface
 

--- a/tests/openwrt/test_interfaces_dsa.py
+++ b/tests/openwrt/test_interfaces_dsa.py
@@ -2029,6 +2029,13 @@ config interface 'vlan_br_lan_1'
         expected['interfaces'][0]['network'] = 'vlan_br_lan_1'
         self.assertEqual(expected, o.config)
 
+    def test_render_vlan8021q_empty_network(self):
+        netjson = deepcopy(self._vlan8021q_netjson)
+        netjson['interfaces'][0]['network'] = ''
+        o = OpenWrt(netjson)
+        expected = self._tabs(self._vlan8021q_uci)
+        self.assertEqual(o.render(), expected)
+
     _vlan8021ad_netjson = {
         "interfaces": [
             {"type": "8021ad", "vid": 6, "name": "eth0", "network": "iot_vlan"}


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Fixes #335


## Description of Changes

If the "network" field in the NetJSON is empty, then auto-generate logical name for the interface.

