### PR TITLE
[fix] Make parameter tls_cipher an array #349

### DIFF
--- a/docs/source/backends/openvpn.rst
+++ b/docs/source/backends/openvpn.rst
@@ -155,7 +155,7 @@ key name                  type    default      allowed values
                                                character
 ``reneg_sec``             integer ``3600``     any positive integer
 ``tls_timeout``           integer ``2``        any positive integer
-``tls_cipher``            string               any string
+``tls_cipher``            list                 list of strings
 ``remote_cert_tls``       string               ``client``, ``server`` or
                                                empty string
 ``float``                 boolean ``False``

--- a/netjsonconfig/backends/openvpn/schema.py
+++ b/netjsonconfig/backends/openvpn/schema.py
@@ -495,8 +495,13 @@ base_openvpn_schema = {
                 "tls_cipher": {
                     "title": "TLS cipher",
                     "description": "A list of allowable TLS ciphers delimited by a colon (':')",
-                    "type": "string",
+                    "type": "array",
                     "propertyOrder": 41,
+                    "additionalItems": True,
+                    "items": {
+                        "title": "cipher",
+                        "type": "string",
+                    },
                 },
                 "remote_cert_tls": {
                     "title": "Remote certificate TLS",


### PR DESCRIPTION
Fixes #349

## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [X] I have updated the documentation.

## Reference to Existing Issue

Closes #349.

## Description of Changes

Made the parameter `tls_cipher` an array and updated the documentation accordingly. There were no tests to update.