### PR TITLE
[change] Merging with wrong format now raises Validation error #351

### DIFF
--- a/netjsonconfig/exceptions.py
+++ b/netjsonconfig/exceptions.py
@@ -7,6 +7,10 @@ def _list_errors(e):
     :param e: ``jsonschema.exceptions.ValidationError`` instance
     """
     error_list = []
+    if not getattr(e, "context", None):
+        return error_list
+    if not getattr(e, "validator_value", None):
+        return error_list
     for value, error in zip(e.validator_value, e.context):
         error_list.append((value, error.message))
         if error.context:
@@ -25,6 +29,8 @@ class NetJsonConfigException(Exception):
             self.details,
         )
         errors = _list_errors(self.details)
+        if not errors:
+            return message
         separator = "\nAgainst schema %s\n%s\n"
         details = reduce(lambda x, y: x + separator % y, errors, "")
         return message + details

--- a/netjsonconfig/utils.py
+++ b/netjsonconfig/utils.py
@@ -3,12 +3,6 @@ from collections import OrderedDict
 from copy import deepcopy
 
 
-class ValidationError(Exception):
-    """exception for validation errors during config merge"""
-
-    pass
-
-
 def merge_config(template, config, list_identifiers=None):
     """
     Merges ``config`` on top of ``template``.
@@ -28,25 +22,10 @@ def merge_config(template, config, list_identifiers=None):
     """
     result = deepcopy(template)
     for key, value in config.items():
-        if isinstance(value, dict):
-            if isinstance(result.get(key), dict) or key not in result:
-                node = result.get(key, OrderedDict())
-                result[key] = merge_config(node, value)
-            else:
-                raise ValidationError(
-                    f"Cannot merge dict into non-dict for key '{key}': "
-                    f"{type(result.get(key)).__name__} vs dict"
-                )
-        elif isinstance(value, list):
-            if isinstance(result.get(key), list):
-                result[key] = merge_list(result[key], value, list_identifiers)
-            elif key in result:
-                raise ValidationError(
-                    f"Cannot merge list into non-list for key '{key}': "
-                    f"{type(result.get(key)).__name__} vs list"
-                )
-            else:
-                result[key] = value
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = merge_config(result.get(key), value, list_identifiers)
+        elif isinstance(value, list) and isinstance(result.get(key), list):
+            result[key] = merge_list(result[key], value, list_identifiers)
         else:
             result[key] = value
     return result

--- a/netjsonconfig/utils.py
+++ b/netjsonconfig/utils.py
@@ -3,6 +3,12 @@ from collections import OrderedDict
 from copy import deepcopy
 
 
+class ValidationError(Exception):
+    """exception for validation errors during config merge"""
+
+    pass
+
+
 def merge_config(template, config, list_identifiers=None):
     """
     Merges ``config`` on top of ``template``.
@@ -23,10 +29,24 @@ def merge_config(template, config, list_identifiers=None):
     result = deepcopy(template)
     for key, value in config.items():
         if isinstance(value, dict):
-            node = result.get(key, OrderedDict())
-            result[key] = merge_config(node, value)
-        elif isinstance(value, list) and isinstance(result.get(key), list):
-            result[key] = merge_list(result[key], value, list_identifiers)
+            if isinstance(result.get(key), dict) or key not in result:
+                node = result.get(key, OrderedDict())
+                result[key] = merge_config(node, value)
+            else:
+                raise ValidationError(
+                    f"Cannot merge dict into non-dict for key '{key}': "
+                    f"{type(result.get(key)).__name__} vs dict"
+                )
+        elif isinstance(value, list):
+            if isinstance(result.get(key), list):
+                result[key] = merge_list(result[key], value, list_identifiers)
+            elif key in result:
+                raise ValidationError(
+                    f"Cannot merge list into non-list for key '{key}': "
+                    f"{type(result.get(key)).__name__} vs list"
+                )
+            else:
+                result[key] = value
         else:
             result[key] = value
     return result

--- a/netjsonconfig/utils.py
+++ b/netjsonconfig/utils.py
@@ -2,6 +2,10 @@ import re
 from collections import OrderedDict
 from copy import deepcopy
 
+from jsonschema import ValidationError as JsonSchemaError
+
+from .exceptions import ValidationError
+
 
 def merge_config(template, config, list_identifiers=None):
     """
@@ -19,6 +23,7 @@ def merge_config(template, config, list_identifiers=None):
     :param config: config ``dict``
     :param list_identifiers: ``list`` or ``None``
     :returns: merged ``dict``
+    :raises ValidationError: if incompatible types are found
     """
     result = deepcopy(template)
     for key, value in config.items():
@@ -26,6 +31,13 @@ def merge_config(template, config, list_identifiers=None):
             result[key] = merge_config(result.get(key), value, list_identifiers)
         elif isinstance(value, list) and isinstance(result.get(key), list):
             result[key] = merge_list(result[key], value, list_identifiers)
+        elif result.get(key) is not None and type(value) is not type(result.get(key)):
+            raise ValidationError(
+                JsonSchemaError(
+                    f"incompatible types for '{key}': expected {type(result.get(key)).__name__}, "
+                    f"got {type(value).__name__}"
+                )
+            )
         else:
             result[key] = value
     return result

--- a/netjsonconfig/utils.py
+++ b/netjsonconfig/utils.py
@@ -27,14 +27,19 @@ def merge_config(template, config, list_identifiers=None):
     """
     result = deepcopy(template)
     for key, value in config.items():
-        if isinstance(value, dict) and isinstance(result.get(key), dict):
-            result[key] = merge_config(result.get(key), value, list_identifiers)
-        elif isinstance(value, list) and isinstance(result.get(key), list):
-            result[key] = merge_list(result[key], value, list_identifiers)
-        elif result.get(key) is not None and type(value) is not type(result.get(key)):
+        existing = result.get(key)
+        if isinstance(value, dict) and isinstance(existing, dict):
+            result[key] = merge_config(existing, value, list_identifiers)
+        elif isinstance(value, list) and isinstance(existing, list):
+            result[key] = merge_list(existing, value, list_identifiers)
+        elif (
+            existing is not None
+            and (isinstance(value, (dict, list)) or isinstance(existing, (dict, list)))
+            and type(value) is not type(existing)
+        ):
             raise ValidationError(
                 JsonSchemaError(
-                    f"incompatible types for '{key}': expected {type(result.get(key)).__name__}, "
+                    f"incompatible types for '{key}': expected {type(existing).__name__}, "
                     f"got {type(value).__name__}"
                 )
             )

--- a/netjsonconfig/utils.py
+++ b/netjsonconfig/utils.py
@@ -40,8 +40,8 @@ def merge_config(template, config, list_identifiers=None):
         ):
             raise ValidationError(
                 JsonSchemaError(
-                    f"incompatible types for '{key}': expected {type(existing).__name__}, "
-                    f"got {type(value).__name__}"
+                    f"Incompatible type for '{key}': expected {type(existing).__name__}, "
+                    f"got {type(value).__name__}."
                 )
             )
         else:

--- a/netjsonconfig/utils.py
+++ b/netjsonconfig/utils.py
@@ -34,7 +34,8 @@ def merge_config(template, config, list_identifiers=None):
             result[key] = merge_list(existing, value, list_identifiers)
         elif (
             existing is not None
-            and (isinstance(value, (dict, list)) or isinstance(existing, (dict, list)))
+            and isinstance(existing, (dict, list))
+            and isinstance(value, (dict, list))
             and type(value) is not type(existing)
         ):
             raise ValidationError(

--- a/tests/openwrt/test_default.py
+++ b/tests/openwrt/test_default.py
@@ -3,7 +3,7 @@ import unittest
 from openwisp_utils.tests import capture_stdout
 
 from netjsonconfig import OpenWrt
-from netjsonconfig.utils import ValidationError, _TabsMixin
+from netjsonconfig.utils import _TabsMixin
 
 
 class TestDefault(unittest.TestCase, _TabsMixin):
@@ -274,7 +274,5 @@ config olsrv2 'internet_hna'
                 }
             ]
         }
-        with self.assertRaises(ValidationError) as context:
-            OpenWrt({}, templates=[valid, invalid]).validate()
-
-        self.assertIn("Cannot merge dict into non-dict", str(context.exception))
+        o = OpenWrt({}, templates=[valid, invalid])
+        o.validate()

--- a/tests/openwrt/test_default.py
+++ b/tests/openwrt/test_default.py
@@ -3,6 +3,7 @@ import unittest
 from openwisp_utils.tests import capture_stdout
 
 from netjsonconfig import OpenWrt
+from netjsonconfig.exceptions import ValidationError
 from netjsonconfig.utils import _TabsMixin
 
 
@@ -268,5 +269,5 @@ config olsrv2 'internet_hna'
                 }
             ]
         }
-        o = OpenWrt({}, templates=[valid, invalid])
-        o.validate()
+        with self.assertRaises(ValidationError):
+            OpenWrt({}, templates=[valid, invalid])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import unittest
 
+from netjsonconfig.exceptions import ValidationError
 from netjsonconfig.utils import evaluate_vars, get_copy, merge_config, merge_list
 
 
@@ -54,6 +55,20 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(
             result, {"list": [{"a": "original"}, {"b": "changed"}, {"c": "original"}]}
         )
+
+    def test_merge_config_list_scalar_overrides(self):
+        template = {"server": ["1.1.1.1"]}
+        config = {"server": "8.8.8.8"}
+        result = merge_config(template, config)
+        self.assertEqual(result, {"server": "8.8.8.8"})
+
+    def test_merge_config_incompatible_dict_list(self):
+        template = {"a": {"b": "c"}}
+        config = {"a": ["x"]}
+        with self.assertRaises(ValidationError) as context:
+            merge_config(template, config)
+        self.assertIn("incompatible types", str(context.exception))
+        self.assertIn("ValidationError", str(context.exception))
 
     def test_evaluate_vars(self):
         self.assertEqual(evaluate_vars("{{ tz }}", {"tz": "UTC"}), "UTC")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,7 +67,7 @@ class TestUtils(unittest.TestCase):
         config = {"a": ["x"]}
         with self.assertRaises(ValidationError) as context:
             merge_config(template, config)
-        self.assertIn("incompatible types", str(context.exception))
+        self.assertIn("Incompatible type", str(context.exception))
         self.assertIn("ValidationError", str(context.exception))
 
     def test_evaluate_vars(self):


### PR DESCRIPTION
An attempt to merge config with wrong format will now raise a validation error instead of failing.

Fixes #351

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #351 

## Description of Changes

Added conditionals to check if two template types can be merged and if not raise validation error instead of failing.
