### PR TITLE
[feature] Add support for BATMAN-adv and 802.11s mesh interfaces in O…

### DIFF
--- a/netjsonconfig/backends/openwrt/converters/wireguard_peers.py
+++ b/netjsonconfig/backends/openwrt/converters/wireguard_peers.py
@@ -10,6 +10,13 @@ class WireguardPeers(OpenWrtConverter):
     # wireguard OpenWRT package, this is unpredictable
     _uci_types = None
 
+    def should_skip_block(self, block):
+        """
+        Override should_skip_block to only process blocks with .type starting with 'wireguard_'
+        """
+        _type = block.get(".type", "")
+        return not _type.startswith("wireguard_")
+
     def to_intermediate_loop(self, block, result, index=None):
         result.setdefault("network", [])
         result["network"].append(self.__intermediate_peer(block, index))

--- a/netjsonconfig/backends/openwrt/schema.py
+++ b/netjsonconfig/backends/openwrt/schema.py
@@ -735,6 +735,119 @@ schema = merge_config(
                     {"$ref": "#/definitions/base_interface_settings"},
                 ],
             },
+            "batadv_interface": {
+                "title": "BATMAN-adv Interface",
+                "type": "object",
+                "required": ["type", "proto", "name"],
+                "allOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["batadv"],
+                                "default": "batadv",
+                                "propertyOrder": 1,
+                            },
+                            "proto": {
+                                "type": "string",
+                                "enum": ["batadv"],
+                                "default": "batadv",
+                                "propertyOrder": 2,
+                            },
+                            "name": {"type": "string", "propertyOrder": 3},
+                            "routing_algo": {
+                                "type": "string",
+                                "enum": ["BATMAN_IV", "BATMAN_V"],
+                                "default": "BATMAN_IV",
+                                "propertyOrder": 4,
+                            },
+                            "bridge_loop_avoidance": {
+                                "type": "boolean",
+                                "format": "checkbox",
+                                "default": True,
+                                "propertyOrder": 5,
+                            },
+                            "gw_mode": {
+                                "type": "string",
+                                "enum": ["off", "client", "server"],
+                                "default": "off",
+                                "propertyOrder": 6,
+                            },
+                            "hop_penalty": {
+                                "type": "integer",
+                                "default": 30,
+                                "propertyOrder": 7,
+                            },
+                            "mtu": {
+                                "type": "integer",
+                                "default": 1500,
+                                "propertyOrder": 8,
+                            },
+                            "fragmentation": {
+                                "type": "boolean",
+                                "format": "checkbox",
+                                "default": True,
+                                "propertyOrder": 9,
+                            },
+                        }
+                    },
+                    {"$ref": "#/definitions/base_interface_settings"},
+                ],
+            },
+            "batadv_hardif_interface": {
+                "title": "BATMAN-adv Hard Interface",
+                "type": "object",
+                "required": ["type", "proto", "name", "device", "master"],
+                "allOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["batadv_hardif"],
+                                "default": "batadv_hardif",
+                                "propertyOrder": 1,
+                            },
+                            "proto": {
+                                "type": "string",
+                                "enum": ["batadv_hardif"],
+                                "default": "batadv_hardif",
+                                "propertyOrder": 2,
+                            },
+                            "name": {"type": "string", "propertyOrder": 3},
+                            "device": {"type": "string", "propertyOrder": 4},
+                            "master": {"type": "string", "propertyOrder": 5},
+                        }
+                    },
+                    {"$ref": "#/definitions/base_interface_settings"},
+                ],
+            },
+            "mesh_interface": {
+                "title": "Mesh Interface (802.11s)",
+                "type": "object",
+                "required": ["type", "proto", "name", "device", "master"],
+                "allOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["mesh"],
+                                "default": "mesh",
+                                "propertyOrder": 1,
+                            },
+                            "proto": {
+                                "type": "string",
+                                "enum": ["batadv_hardif"],
+                                "default": "batadv_hardif",
+                                "propertyOrder": 2,
+                            },
+                            "name": {"type": "string", "propertyOrder": 3},
+                            "device": {"type": "string", "propertyOrder": 4},
+                            "master": {"type": "string", "propertyOrder": 5},
+                        }
+                    },
+                    {"$ref": "#/definitions/base_interface_settings"},
+                ],
+            },
             "base_radio_settings": {
                 "properties": {
                     "driver": {
@@ -973,6 +1086,9 @@ schema = merge_config(
                         {"$ref": "#/definitions/wireguard_interface"},
                         {"$ref": "#/definitions/vlan_8021q"},
                         {"$ref": "#/definitions/vlan_8021ad"},
+                        {"$ref": "#/definitions/batadv_interface"},
+                        {"$ref": "#/definitions/batadv_hardif_interface"},
+                        {"$ref": "#/definitions/mesh_interface"},
                     ]
                 }
             },

--- a/netjsonconfig/schema.py
+++ b/netjsonconfig/schema.py
@@ -295,6 +295,19 @@ schema = {
                     "maximum": 2346,
                     "propertyOrder": 12,
                 },
+                "mesh_fwding": {
+                    "type": "string",
+                    "title": "mesh forwarding",
+                    "description": "802.11s mesh forwarding",
+                    "enum": ["0", "1"],
+                    "propertyOrder": 13,
+                },
+                "mesh_rssi_threshold": {
+                    "type": "string",
+                    "title": "mesh RSSI threshold",
+                    "description": "802.11s mesh RSSI threshold",
+                    "propertyOrder": 14,
+                },
             },
         },
         "ssid_wireless_property": {
@@ -407,7 +420,7 @@ schema = {
                     "propertyOrder": 20,
                     "oneOf": [
                         {"$ref": "#/definitions/encryption_none"},
-                        {"$ref": "#/definitions/encryption_wpa3_personal"},
+                        {"$ref": "#/definitions/encryption_wpa3_personal_mesh"},
                         {"$ref": "#/definitions/encryption_wpa_personal"},
                         {"$ref": "#/definitions/encryption_wep"},
                     ],
@@ -472,6 +485,21 @@ schema = {
                 }
             },
         },
+        "encryption_cipher_mesh": {
+            "properties": {
+                "cipher": {
+                    "type": "string",
+                    "enum": ["auto", "ccmp"],
+                    "options": {
+                        "enum_titles": [
+                            "auto",
+                            "Force CCMP (AES)",
+                        ]
+                    },
+                    "propertyOrder": 3,
+                }
+            }
+        },
         "encryption_mfp_property": {
             "properties": {
                 "ieee80211w": {
@@ -534,6 +562,22 @@ schema = {
                 {"$ref": "#/definitions/encryption_base_settings"},
                 {"$ref": "#/definitions/encryption_cipher_ccmp_required"},
                 {"$ref": "#/definitions/encryption_mfp_property_required"},
+                {
+                    "properties": {
+                        "protocol": {
+                            "enum": ["wpa3_personal"],
+                            "options": {"enum_titles": ["WPA3 Personal"]},
+                        },
+                        "key": {"minLength": 8},
+                    }
+                },
+            ],
+        },
+        "encryption_wpa3_personal_mesh": {
+            "title": "WPA3 Personal (Mesh)",
+            "allOf": [
+                {"$ref": "#/definitions/encryption_base_settings"},
+                {"$ref": "#/definitions/encryption_cipher_mesh"},
                 {
                     "properties": {
                         "protocol": {


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #368 

## Description
This PR adds comprehensive support for BATMAN-adv (Better Approach To Mobile Ad-hoc Networking) mesh networking protocol and 802.11s wireless mesh interfaces to the OpenWrt  backend.

## Changes

### New Interface Types
Implements three new interface types for the OpenWrt backend:

  - **`batadv`**: Main BATMAN-adv virtual mesh interface
    - Configurable routing algorithm (BATMAN_IV, BATMAN_V)
    - Bridge loop avoidance settings
    - Gateway mode (off, client, server)
    - Hop penalty, MTU, and fragmentation controls

  - **`batadv_hardif`**: Physical/hard interfaces for mesh participation
    - Device binding and master interface association

  - **`mesh`**: Convenience alias for 802.11s wireless mesh interfaces (equivalent to `batadv_hardif`)

  ### Schema Extensions
  - Added JSON Schema definitions for all three interface types
  - Added mesh-specific wireless properties (`mesh_fwding`, `mesh_rssi_threshold`)
  - Added WPA3 Personal encryption support for mesh networks with CCMP cipher

  ### Converter Implementation
  - Implemented bidirectional conversion (NetJSON ↔ OpenWrt UCI) in the `Interfaces` converter
  - Added forward conversion methods: `_intermediate_batadv`, `_intermediate_batadv_hardif`, `_intermediate_mesh`
  - Added backward conversion methods: `_netjson_batadv`, `_netjson_batadv_hardif`, `_netjson_mesh`
  - Updated `WireguardPeers` converter to properly filter blocks by type

  ### Documentation
  - Added comprehensive documentation to `docs/source/backends/openwrt.rst` (197 lines)
  - Included configuration parameter reference tables
  - Provided multiple working examples (basic and complete mesh setups)

  ## Files Changed
  - `docs/source/backends/openwrt.rst` (+197 lines)
  - `netjsonconfig/backends/openwrt/converters/interfaces.py` (+58 lines)
  - `netjsonconfig/backends/openwrt/converters/wireguard_peers.py` (+7 lines)
  - `netjsonconfig/backends/openwrt/schema.py` (+116 lines)
  - `netjsonconfig/schema.py` (+46 lines)

  **Total: 424 insertions, 1 deletion**

  ## Testing
  - [x] All existing tests pass
  - [x] New converter methods tested
  - [x] Schema validation tested
  - [x] Documentation examples verified

  ## Backward Compatibility
  -  Maintains full backward compatibility with existing configurations
  -  No breaking changes to existing interface types
  -  Follows established netjsonconfig converter patterns
